### PR TITLE
DO NOT MERGE: add example navigation bar

### DIFF
--- a/frontend/src/components/NavigationPanel.js
+++ b/frontend/src/components/NavigationPanel.js
@@ -8,11 +8,21 @@ import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+import ListSubheader from '@material-ui/core/ListSubheader';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 
+import CreateChannelIcon from '@material-ui/icons/AddToQueue';
+import ChannelIcon from '@material-ui/icons/VideoLibrary';
 import LatestMediaIcon from '@material-ui/icons/NewReleases';
+import HomeIcon from '@material-ui/icons/Home';
+import PopularIcon from '@material-ui/icons/TrendingUp';
+import FeedbackIcon from '@material-ui/icons/Feedback';
+import HelpIcon from '@material-ui/icons/Help';
+import SettingsIcon from '@material-ui/icons/Settings';
 
 /** Side panel for the current user providing navigation links. */
 const NavigationPanel = ({ profile, classes }) => <div className={ classes.root }>
@@ -48,21 +58,75 @@ const NavigationPanel = ({ profile, classes }) => <div className={ classes.root 
     null
   }
   </div>
-  <Divider />
-  <List>
-    <ListItem button component={Link} to='/'>
-      <ListItemText primary="Latest Media" />
-    </ListItem>
-    {
-      profile && !profile.isAnonymous
-      ?
-      <ListItem button component='a' href='/accounts/logout'>
-        <ListItemText primary="Sign out" />
+  <div className={classes.main}>
+    <Divider />
+    <List>
+      <ListItem button component={Link} to='/'>
+        <ListItemIcon><HomeIcon /></ListItemIcon>
+        <ListItemText primary="Home" />
       </ListItem>
-      :
-      null
-    }
-  </List>
+      <ListItem button component={Link} to='/'>
+        <ListItemIcon><PopularIcon /></ListItemIcon>
+        <ListItemText primary="Popular" />
+      </ListItem>
+    </List>
+    <Divider />
+    <List subheader={<ListSubheader>Channels</ListSubheader>}>
+      <ListItem button>
+        <ListItemAvatar><Avatar>G</Avatar></ListItemAvatar>
+        <ListItemText classes={{ root: classes.listItemRoot }}
+          secondary="47 items" primary="Philosophers of Greece" />
+      </ListItem>
+      <ListItem button>
+        <ListItemAvatar><Avatar src="https://randomuser.me/api/portraits/thumb/women/65.jpg" /></ListItemAvatar>
+        <ListItemText classes={{ root: classes.listItemRoot }}
+          secondary="1 item" primary="Smith Lectures" />
+      </ListItem>
+      <ListItem button>
+        <ListItemAvatar><Avatar
+src="http://www.sjcchoir.co.uk/sites/default/files/styles/main_content_small_image/public/images/125_col_small_st_johns_choir_17x15_c_b_ealovega.jpg?itok=8Y3mjZ1I" /></ListItemAvatar>
+        <ListItemText classes={{ root: classes.listItemRoot }} 
+          secondary="341 items" primary="St John's Choir" />
+      </ListItem>
+    </List>
+    <Divider />
+    <List>
+      <ListItem button>
+        <ListItemIcon><ChannelIcon /></ListItemIcon>
+        <ListItemText primary="Manage channels" />
+      </ListItem>
+      <ListItem button>
+        <ListItemIcon><HelpIcon /></ListItemIcon>
+        <ListItemText primary="Help" />
+      </ListItem>
+      <ListItem button>
+        <ListItemIcon><FeedbackIcon /></ListItemIcon>
+        <ListItemText primary="Feedback" />
+      </ListItem>
+    </List>
+  </div>
+  {
+    profile && !profile.isAnonymous
+    ?
+    <div className={classes.bottom}>
+      <Divider />
+      <div className={classes.bottomPanel}>
+        <Typography gutterBottom variant='caption'>
+          <a href="/account/logout">Sign out</a>
+        </Typography>
+        <Typography variant='caption'>
+          <a href="/about">About</a>{' '}
+          <a href="#">Contact</a>{' '}
+          <a href="https://github.com/uisautomation/sms-webapp">Developers</a>{' '}
+        </Typography>
+        <Typography variant='caption'>
+          &copy; 2018 University of Cambridge
+        </Typography>
+      </div>
+    </div>
+    :
+    null
+  }
 </div>;
 
 NavigationPanel.propTypes = {
@@ -76,12 +140,40 @@ NavigationPanel.propTypes = {
 };
 
 const styles = theme => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+
+  main: {
+    flexGrow: 1,
+  },
+
   avatar: {
     marginBottom: theme.spacing.unit * 2,
   },
 
+  bottomPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    paddingBottom: theme.spacing.unit * 2,
+    paddingLeft: theme.spacing.unit * 3,
+    paddingRight: theme.spacing.unit * 3,
+    paddingTop: theme.spacing.unit * 2,
+
+    '& a': {
+      color: 'inherit',
+      textDecoration: 'inherit',
+    },
+
+    '& a:hover': {
+      textDecoration: 'underline',
+    },
+  },
+
   profileBar: {
-    ...theme.mixins.toolbar,
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -91,7 +183,15 @@ const styles = theme => ({
       paddingLeft: theme.spacing.unit * 3,
       paddingRight: theme.spacing.unit * 3,
     },
-  }
+  },
+
+  listItemRoot: {
+    '& *': {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+  },
 });
 
 export default withStyles(styles)(NavigationPanel);

--- a/frontend/src/components/NavigationPanel.js
+++ b/frontend/src/components/NavigationPanel.js
@@ -12,10 +12,11 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListSubheader from '@material-ui/core/ListSubheader';
+import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 
-import CreateChannelIcon from '@material-ui/icons/AddToQueue';
+import CreateChannelIcon from '@material-ui/icons/LibraryAdd';
 import ChannelIcon from '@material-ui/icons/VideoLibrary';
 import LatestMediaIcon from '@material-ui/icons/NewReleases';
 import HomeIcon from '@material-ui/icons/Home';
@@ -23,6 +24,10 @@ import PopularIcon from '@material-ui/icons/TrendingUp';
 import FeedbackIcon from '@material-ui/icons/Feedback';
 import HelpIcon from '@material-ui/icons/Help';
 import SettingsIcon from '@material-ui/icons/Settings';
+import DropDownIcon from '@material-ui/icons/ArrowDropDown';
+import SignOutIcon from '@material-ui/icons/ExitToApp';
+import ShowMoreIcon from '@material-ui/icons/KeyboardArrowDown';
+import UploadIcon from '@material-ui/icons/CloudUpload';
 
 /** Side panel for the current user providing navigation links. */
 const NavigationPanel = ({ profile, classes }) => <div className={ classes.root }>
@@ -39,7 +44,11 @@ const NavigationPanel = ({ profile, classes }) => <div className={ classes.root 
         { profile.avatarImageUrl ? null : profile.displayName[0] }
       </Avatar>
       <Typography variant='title'>{ profile.displayName }</Typography>
-      <Typography variant='caption'>{ profile.username }</Typography>
+      <div className={ classes.profileUsernameContainer }>
+        <Typography variant='caption' className={ classes.profileUsername }>
+          { profile.username }
+        </Typography>
+      </div>
     </div>
     :
     null
@@ -65,43 +74,53 @@ const NavigationPanel = ({ profile, classes }) => <div className={ classes.root 
         <ListItemIcon><HomeIcon /></ListItemIcon>
         <ListItemText primary="Home" />
       </ListItem>
-      <ListItem button component={Link} to='/'>
-        <ListItemIcon><PopularIcon /></ListItemIcon>
-        <ListItemText primary="Popular" />
+      <ListItem button component={Link} to='/upload'>
+        <ListItemIcon><UploadIcon /></ListItemIcon>
+        <ListItemText primary="Upload" />
       </ListItem>
     </List>
     <Divider />
     <List subheader={<ListSubheader>Channels</ListSubheader>}>
       <ListItem button>
-        <ListItemAvatar><Avatar>G</Avatar></ListItemAvatar>
+        <ListItemIcon><CreateChannelIcon /></ListItemIcon>
         <ListItemText classes={{ root: classes.listItemRoot }}
-          secondary="47 items" primary="Philosophers of Greece" />
+          primary="Create channel" />
       </ListItem>
       <ListItem button>
-        <ListItemAvatar><Avatar src="https://randomuser.me/api/portraits/thumb/women/65.jpg" /></ListItemAvatar>
+        <ListItemAvatar><Avatar className={ classes.channelAvatar }>P</Avatar></ListItemAvatar>
+        <ListItemText classes={{ root: classes.listItemRoot }}
+          secondary="47 items" primary="Philosophers of Ancient Greece" />
+      </ListItem>
+      <ListItem button>
+        <ListItemAvatar><Avatar className={ classes.channelAvatar } src="https://randomuser.me/api/portraits/thumb/women/65.jpg" /></ListItemAvatar>
         <ListItemText classes={{ root: classes.listItemRoot }}
           secondary="1 item" primary="Smith Lectures" />
       </ListItem>
       <ListItem button>
-        <ListItemAvatar><Avatar
+        <ListItemAvatar><Avatar className={ classes.channelAvatar }
 src="http://www.sjcchoir.co.uk/sites/default/files/styles/main_content_small_image/public/images/125_col_small_st_johns_choir_17x15_c_b_ealovega.jpg?itok=8Y3mjZ1I" /></ListItemAvatar>
         <ListItemText classes={{ root: classes.listItemRoot }} 
           secondary="341 items" primary="St John's Choir" />
+      </ListItem>
+      <ListItem button>
+        <ListItemIcon><ShowMoreIcon /></ListItemIcon>
+        <ListItemText classes={{ root: classes.listItemRoot }}
+          primary="Show more" />
       </ListItem>
     </List>
     <Divider />
     <List>
       <ListItem button>
-        <ListItemIcon><ChannelIcon /></ListItemIcon>
-        <ListItemText primary="Manage channels" />
+        <ListItemIcon><FeedbackIcon /></ListItemIcon>
+        <ListItemText primary="Feedback" />
       </ListItem>
       <ListItem button>
         <ListItemIcon><HelpIcon /></ListItemIcon>
         <ListItemText primary="Help" />
       </ListItem>
-      <ListItem button>
-        <ListItemIcon><FeedbackIcon /></ListItemIcon>
-        <ListItemText primary="Feedback" />
+      <ListItem button component='a' href='/accounts/logout'>
+        <ListItemIcon><SignOutIcon /></ListItemIcon>
+        <ListItemText primary="Sign out" />
       </ListItem>
     </List>
   </div>
@@ -111,13 +130,10 @@ src="http://www.sjcchoir.co.uk/sites/default/files/styles/main_content_small_ima
     <div className={classes.bottom}>
       <Divider />
       <div className={classes.bottomPanel}>
-        <Typography gutterBottom variant='caption'>
-          <a href="/account/logout">Sign out</a>
-        </Typography>
-        <Typography variant='caption'>
-          <a href="/about">About</a>{' '}
-          <a href="#">Contact</a>{' '}
-          <a href="https://github.com/uisautomation/sms-webapp">Developers</a>{' '}
+        <Typography variant='caption' gutterBottom className={ classes.bottomLinks }>
+          <a href="/about">About</a>
+          <a href="#">Contact</a>
+          <a href="https://github.com/uisautomation/sms-webapp">Developers</a>
         </Typography>
         <Typography variant='caption'>
           &copy; 2018 University of Cambridge
@@ -191,6 +207,23 @@ const styles = theme => ({
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
     },
+  },
+
+  bottomLinks: {
+    '& > a': {
+      marginRight: theme.spacing.unit,
+    },
+  },
+
+  profileUsernameContainer: {
+    display: 'flex',
+  },
+
+  profileUsername: {
+    flexGrow: 1,
+  },
+
+  channelAvatar: {
   },
 });
 

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -38,7 +38,7 @@ const theme = createMuiTheme({
     },
   },
   dimensions: {
-    drawerWidth: 30 * 8,
+    drawerWidth: 36 * 8,
   },
   overrides: {
     MuiTypography: {


### PR DESCRIPTION
> **DO NOT MERGE THIS PR.** It is intended for design discussion only.

> **UPDATE** Version 2 has been posted below.

This PR implements a sketch of how the navigation bar could look when populated with content. The content is entirely fake at the moment but illustrates some ideas for the design of the navigation bar.

![screenshot_2018-08-24 the university of cambridge media platform](https://user-images.githubusercontent.com/146860/44610904-58e50e80-a7f6-11e8-8fb8-a47fbfbbc416.png)

The PR includes code rather than just a screenshot so that the design can be tested in a variety of browsers and a variety of a screen sizes. It's intended to be the starting point for discussion much as #226 was.

### Summary of changes

1. The sign out link is reduced in visibility. This is an action that people are unlikely to want to perform so we need not take up valuable vertical screen estate with it.
2. Along with the sign out link we have links to other "secondary" navigation targets such as the "about" page, a "contact" page and a link for developers. It's important to *have* the developers' link since we should be friendly to other dev teams in the University and encourage reuse of code, etc.
3. Add a copyright notice.
4. Add a list of the user's channels. Following a link takes the user to the channel page where edit actions are available.
5. The navigation drawer has been widened by 6 spacing units. This is to allow greater room for channel names but, in accordance with the Material Design guidelines, list items do not have their heading split over multiple lines. To deal with long channel names, we "ellipsis-ise" them. This has the nice side-benefit of encouraging our users to choose snappy titles for channels.

### Rationale

It's likely that the primary interaction a user will have with the site will be to manage their channels. Each channel the user manages is available in the navigation bar. The "manage channels" destination could be an "add channel" page but navigation links should generally be nouns, not verbs.

Aside from managing channels, the other primary navigation targets for the alpha are likely to be the "help" pages and the "feedback" mechanism.

The remaining navigation destinations have been de-emphasised and placed in a lower panel. They represent navigation targets which are less important to general users.

### Other screenshots

iPhone drawer open

![screen shot 2018-08-24 at 23 56 25](https://user-images.githubusercontent.com/146860/44611512-6c45a900-a7f9-11e8-94e2-8fcef17aaafb.png)