### PR TITLE
enable versioning for media items and channels

### DIFF
--- a/mediaplatform/admin.py
+++ b/mediaplatform/admin.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.formats import localize
 from django.utils.html import format_html
+from reversion.admin import VersionAdmin
 
 from mediaplatform_jwp import models as jwpmodels
 from mediaplatform_jwp.api import delivery as api
@@ -100,7 +101,7 @@ class MediaItemAdminForm(forms.ModelForm):
 
 
 @admin.register(models.MediaItem)
-class MediaItemAdmin(admin.ModelAdmin):
+class MediaItemAdmin(VersionAdmin):
     fields = (
         'preview', 'channel', 'type', 'title', 'description', 'formatted_duration',
         'published_at', 'downloadable', 'tags', 'language', 'copyright', 'created_at',
@@ -191,7 +192,7 @@ class ChannelAdminForm(forms.ModelForm):
 
 
 @admin.register(models.Channel)
-class ChannelAdmin(admin.ModelAdmin):
+class ChannelAdmin(VersionAdmin):
     fields = (
         'title', 'description', 'item_count', 'owning_lookup_inst', 'created_at', 'updated_at',
         'deleted_at'

--- a/mediawebapp/settings/base.py
+++ b/mediawebapp/settings/base.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'ucamwebauth',
     'robots',
+    'reversion',
 
     'smsjwplatform',
     'legacysms',
@@ -58,7 +59,8 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'mediawebapp.middleware.user_lookup_middleware'
+    'mediawebapp.middleware.user_lookup_middleware',
+    'reversion.middleware.RevisionMiddleware',
 ]
 
 #: Root URL patterns

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ python-dateutil
 django-crispy-forms
 django-filter
 django-robots
+django-reversion
 
 # For loading fixtures
 PyYAML


### PR DESCRIPTION
Use the django-reversion package to enable versioning for the media item and channel objects. This gets logging and delete protection "for free".  After this has bedded down for a while, we can probably remove the "deleted_at" fields from MediaItem and Channel.

This commit uses the django-reversion middleware to wrap *every* non GET/HEAD/OPTIONS request. This is probably a little heavy handed but makes sure we catch all of the ways we could mutate an object via the UI/API.

It's not currently clear how the django-reversion module can be used with any non Django session authentication used by DRF. Until we add such authentication, this is a non-issue but it should be fairly easy to create a version of https://django-reversion.readthedocs.io/en/stable/views.html which works with DRF as a mixin class much like reversion.views.RevisionMixin.  Unlike the RevisionMixin class, the DRF one would wrap the dispatch() method of a DRF view and wrap non GET/HEAD/OPTIONS requests with a revision.

This has the advantage that we can be a bit more "surgical" in which views we revision.

Happy to provide a more "in depth" version of this PR which does this if we feel it's worthwhile at this stage.

### Deployment

Read the [management command](https://django-reversion.readthedocs.io/en/stable/commands.html) documentation carefully for reversion. We probably want to schedule a cronjob to run something like ``./manage.py deleterevisions mediaplatform.MediaItem --keep=3 --days=30`` every day or so to keep the revision history relatively small.

Closes #275