### PR TITLE
DO NOT MERGE: experimental re-work of media page

### DIFF
--- a/frontend/src/components/CollapsingPaperSection.js
+++ b/frontend/src/components/CollapsingPaperSection.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Paper from '@material-ui/core/Paper';
+import { withStyles } from '@material-ui/core/styles';
+
+const CollapsingPaperSection = ({ classes, children }) => (
+  <Paper classes={{ root: classes.paperRoot, rounded: classes.paperRounded }}>
+    { children }
+  </Paper>
+);
+
+const styles = theme => ({
+  paperRoot: {
+    [theme.breakpoints.up('md')]: {
+      margin: theme.spacing.unit,
+    },
+  },
+
+  paperRounded: {
+    [theme.breakpoints.down('sm')]: {
+      borderRadius: 0,
+    },
+  },
+});
+
+export default withStyles(styles)(CollapsingPaperSection);

--- a/frontend/src/pages/MediaPage.js
+++ b/frontend/src/pages/MediaPage.js
@@ -1,13 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import Fade from '@material-ui/core/Fade';
 import Grid from '@material-ui/core/Grid';
+import Hidden from '@material-ui/core/Hidden';
+import IconButton from '@material-ui/core/IconButton';
+import Input from '@material-ui/core/Input';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Paper from '@material-ui/core/Paper';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import Toolbar from '@material-ui/core/Toolbar';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+
 import { withStyles } from '@material-ui/core/styles';
+
 import DownloadIcon from '@material-ui/icons/CloudDownload';
 import AnalyticsIcon from '@material-ui/icons/ShowChart';
 import EditIcon from '@material-ui/icons/Edit';
+import MoreIcon from '@material-ui/icons/MoreVert';
+import EmbedIcon from '@material-ui/icons/PictureInPicture';
+import BackIcon from '@material-ui/icons/ArrowBack';
 
 import Page from '../containers/Page';
 import BodySection from '../components/BodySection';
@@ -15,6 +35,8 @@ import RenderedMarkdown from '../components/RenderedMarkdown';
 
 import FetchMediaItem from '../containers/FetchMediaItem';
 import IfOwnsChannel from "../containers/IfOwnsChannel";
+
+import CollapsingPaperSection from '../components/CollapsingPaperSection';
 
 /**
  * The media item page
@@ -52,77 +74,103 @@ const bestSource = sources => {
   return null;
 };
 
-const MediaPageContents = ({ resource: item, classes }) => {
-  const source =
-    (item && item.sources) ? bestSource(item.sources) : null;
+class MediaPageContents extends React.Component {
+  state = { }
 
-  return (
-    <div>
-      <section className={ classes.playerSection }>
-        <div className={ classes.playerWrapper }>
-          <iframe
-            src={ item ? item.embedUrl : '' }
-            className={ classes.player }
-            frameBorder="0"
-            allowFullScreen>
-          </iframe>
-        </div>
-      </section>
-      <BodySection classes={{ root: classes.mediaDetails }}>
-        <Grid container spacing={16}>
-          <Grid container item xs={12} md={9} lg={10}>
-            <Grid item xs={12}>
-              <Typography variant="headline" component="div">{ item ? item.title : '' }</Typography>
+  render() {
+    const { resource: item, classes } = this.props;
+    const { embedShown } = this.state;
+    const source =
+      (item && item.sources) ? bestSource(item.sources) : null;
+
+    const embedCode = '<iframe> ... </iframe>';
+
+    return (
+      <div className={ classes.root }>
+        <section className={ classes.playerSection }>
+          <div className={ classes.playerWrapper }>
+            <iframe
+              src={ item ? item.embedUrl : '' }
+              className={ classes.player }
+              frameBorder="0"
+              allowFullScreen>
+            </iframe>
+          </div>
+        </section>
+        <section className={ classes.headingSection }>
+          <AppBar position="static">
+            <Toolbar>
+              <div className={ classes.headingTitle }>
+                <Typography color="inherit" variant="headline" gutterBottom>
+                  { item && item.title }
+                </Typography>
+                {
+                  item && item.channel &&
+                  <Typography color="inherit" variant="caption" gutterBottom>
+                    <div className={ classes.channelBanner }>
+                      <a href={`/channels/${item.channel.id}`}>{ item.channel.title }</a>
+                    </div>
+                  </Typography>
+                }
+              </div>
+            </Toolbar>
+            <Toolbar variant="dense" classes={{ root: classes.actions }}>
+              <Tooltip title="Copy embed code">
+                <IconButton color="inherit">
+                  <EmbedIcon />
+                </IconButton>
+              </Tooltip>
+              {
+                source &&
+                <Tooltip title="Download media">
+                  <IconButton color="inherit" href={ source.url } download={true} target="_blank">
+                    <DownloadIcon />
+                  </IconButton>
+                </Tooltip>
+              }
+              {
+                item &&
+                <Tooltip title="Analytics">
+                  <IconButton
+                    color="inherit" component='a' href={ '/media/' + item.id + '/analytics' }
+                  >
+                    <AnalyticsIcon />
+                  </IconButton>
+                </Tooltip>
+              }
+            </Toolbar>
+          </AppBar>
+        </section>
+        {
+          (item && item.channel)
+          &&
+          <IfOwnsChannel channel={ item.channel }>
+            <Button
+              variant="fab" color="secondary" aria-label="Edit"
+              component="a" href={ '/media/' + item.id + '/edit' }
+              classes={{ root: classes.fab }}
+            >
+              <EditIcon />
+            </Button>
+          </IfOwnsChannel>
+        }
+        <Grid container justify="center">
+          {
+            item && item.description && item.description.trim() !== '' &&
+            <Grid item xs={12} md={10} lg={8} xl={6}>
+              <CollapsingPaperSection>
+                <BodySection>
+                  <div className={ classes.description }>
+                    <RenderedMarkdown source={ item.description } />
+                  </div>
+                </BodySection>
+              </CollapsingPaperSection>
             </Grid>
-            <Grid item xs={12}>
-              <RenderedMarkdown source={ item ? item.description : '' }/>
-            </Grid>
-          </Grid>
-          <Grid item xs={12} md={3} lg={2} className={classes.buttonStack}>
-            {
-              source
-              ?
-              <Button
-                component='a' variant='outlined' target='_blank' className={ classes.link }
-                href={ source.url } download fullWidth
-              >
-                Download
-                <DownloadIcon className={ classes.rightIcon } />
-              </Button>
-              :
-              null
-            }
-            {
-              item && item.id
-              ?
-              <IfOwnsChannel channel={item.channel} className={classes.fullWidth}>
-                <Button component='a' variant='outlined' className={ classes.link }
-                  href={ '/media/' + item.id + '/edit' } fullWidth
-                >
-                  Edit
-                  <EditIcon className={ classes.rightIcon } />
-                </Button>
-              </IfOwnsChannel>
-              :
-              null
-            }
-            {
-              item && item.id
-              ?
-              <Button component='a' variant='outlined' className={ classes.link }
-                href={ '/media/' + item.id + '/analytics' } fullWidth
-              >
-                Statistics
-                <AnalyticsIcon className={ classes.rightIcon } />
-              </Button>
-              :
-              null
-            }
-          </Grid>
+          }
         </Grid>
-      </BodySection>
-    </div>
-  );
+      </div>
+    );
+  }
 }
 
 MediaPageContents.propTypes = {
@@ -132,30 +180,100 @@ MediaPageContents.propTypes = {
 
 /* tslint:disable object-literal-sort-keys */
 var styles = theme => ({
-  mediaDetails: {
-    ...theme.mixins.bodySection,
-    marginTop: theme.spacing.unit * 2,
+  root: {
+    [theme.breakpoints.up('md')]: {
+      paddingBottom: theme.spacing.unit * 3,
+    },
   },
+
+  actions: {
+    backgroundColor: theme.palette.primary.dark,
+
+    '& > *:first-child': {
+      marginLeft: -1.5 * theme.spacing.unit,
+    },
+
+    '& > *:last-child': {
+      marginRight: -1.5 * theme.spacing.unit,
+    },
+  },
+
+  headingTitle: {
+    flexGrow: 1,
+    paddingBottom: theme.spacing.unit * 2,
+    paddingTop: theme.spacing.unit * 2,
+
+    '& a': {
+      color: 'inherit',
+      textDecoration: 'inherit',
+    },
+
+    '& a:hover': {
+      textDecoration: 'underline',
+    },
+
+    [theme.breakpoints.up('md')]: {
+      paddingBottom: theme.spacing.unit * 3,
+      paddingTop: theme.spacing.unit * 3,
+    },
+  },
+
+  headingSection: {
+    [theme.breakpoints.up('md')]: {
+      marginBottom: theme.spacing.unit * 2,
+    },
+  },
+
+  description: {
+    marginBottom: -theme.spacing.unit,
+    paddingBottom: 1, // HACK: fix odd margin spacing for description
+    paddingTop: theme.spacing.unit * 2,
+
+    [theme.breakpoints.up('md')]: {
+      paddingBottom: theme.spacing.unit,
+      paddingTop: theme.spacing.unit * 3,
+    },
+  },
+
+  innerSection: {
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    maxWidth: theme.spacing.unit * 120,
+  },
+
+  channelBanner: {
+    alignContent: 'center',
+    alignItems: 'flex-start',
+    display: 'flex',
+    opacity: 0.54,
+  },
+
+  fab: {
+    bottom: theme.spacing.unit * 2,
+    position: 'absolute',
+    right: theme.spacing.unit * 2,
+  },
+
   // The following rules specify that the player keep itself in 16:9 aspect ratio but is never
-  // larger than 67.5% of the screen height. (We'll come back to why this isn't 66% in a bit.)
-  // Our trick here is to use the fact that padding values are relative to an element's *width*. We
-  // can force a particular aspect ratio by specifying a height of zero and a padding based on the
-  // reciprocal of the aspect ratio. We also want the video to have a maximum height of 67.5vh (see
-  // above). Since the padding value is a function of the width, we need to limit the maximum
-  // *width* of the element, not the height. Fortunately we're doing all this jiggery-pokery to
-  // keep a constant aspect ratio and so a maximum *height* of 67.5vh implies a maximum width of
-  // 67.5vh * 16 / 9 = 120vh.
+  // larger than 54% of the screen height. (We'll come back to why this isn't a rounder number in a
+  // bit.) Our trick here is to use the fact that padding values are relative to an element's
+  // *width*. We can force a particular aspect ratio by specifying a height of zero and a padding
+  // based on the reciprocal of the aspect ratio. We also want the video to have a maximum height
+  // of 54vh (see above). Since the padding value is a function of the width, we need to limit the
+  // maximum *width* of the element, not the height. Fortunately we're doing all this
+  // jiggery-pokery to keep a constant aspect ratio and so a maximum *height* of 54vh implies a
+  // maximum width of 54vh * 16 / 9 = 96vh.
   //
-  // The use of a 67.5% maximum height lets us keep the nice round figure for the maximum height.
+  // The use of a 54% maximum height lets us keep the nice round figure for the maximum height.
   playerSection: {
     backgroundColor: 'black',
-    maxHeight: '67.5vh',
+    maxHeight: '54vh',
     overflow: 'hidden',  // since the player wrapper below can sometimes overhang
   },
   playerWrapper: {
     height: 0,
     margin: [[0, 'auto']],
-    maxWidth: '120vh',
+    maxWidth: '96vh',
     paddingTop: '56.25%', // 16:9
     position: 'relative',
     width: '100%',

--- a/mediawebapp/settings/developer.py
+++ b/mediawebapp/settings/developer.py
@@ -35,11 +35,11 @@ wOq24EIbX5LquL9w+uvnfXw=
 DEBUG = True
 
 INSTALLED_APPS = INSTALLED_APPS + [  # noqa: F405
-    'debug_toolbar',
+#    'debug_toolbar',
 ]
 
 MIDDLEWARE = MIDDLEWARE + [  # noqa: F405
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
+#    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 STATIC_URL = '/static/'


### PR DESCRIPTION
> **DO NOT MERGE THIS PR: IT IS FOR DESIGN DISCUSSION**

This PR has got a sketch of how I think the media page can be improved. We move the actions such as download, embed and show analytics to a dedicated toolbar. The description is paper which auto-collapses on small screens to connect to an app bar used to display the media information.

Add a link to the media's channel in the heading. One may also want to include a channel avatar once we have channel images sorted.

When the user can edit an item, an edit FAB is displayed.

This code is functional as far as is easy. The embed code is not yet copied to the clipboard, for example.

![screen shot 2018-09-09 at 11 59 03](https://user-images.githubusercontent.com/146860/45263791-61f5f280-b428-11e8-92fd-349bbd63406e.png)
![screen shot 2018-09-09 at 11 58 51](https://user-images.githubusercontent.com/146860/45263792-628e8900-b428-11e8-88d6-356a963b6113.png)
![screen shot 2018-09-09 at 11 58 37](https://user-images.githubusercontent.com/146860/45263793-628e8900-b428-11e8-90fd-6b6b438618c8.png)
![screen shot 2018-09-09 at 11 58 06](https://user-images.githubusercontent.com/146860/45263794-628e8900-b428-11e8-8af4-457276900a9e.png)
![screen shot 2018-09-09 at 11 57 46](https://user-images.githubusercontent.com/146860/45263795-628e8900-b428-11e8-9d94-674187c852c2.png)
![screen shot 2018-09-09 at 11 57 21](https://user-images.githubusercontent.com/146860/45263796-628e8900-b428-11e8-9e92-a0604e55df6e.png)