### PR TITLE
pin Django debug toolbar at <1.10

### DIFF
--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -4,7 +4,7 @@
 # Additional requirements useful for developers of the webapp
 
 # Django debugging
-django-debug-toolbar
+django-debug-toolbar<1.10
 
 # Testing
 tox


### PR DESCRIPTION
Release 1.10 of DDT has broken media page views. My guess is that this is related to the serialisation of array parameters in SQL[1]. Until that's fixed, pin the version of DDT to be less.

[1] https://github.com/jazzband/django-debug-toolbar/pull/1079