### PR TITLE
Displaying Additional Statistics

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -323,6 +323,8 @@ class MediaItemAnalyticsListSerializer(serializers.Serializer):
     """
     views_per_day = MediaItemAnalyticsSerializer(source='fetched_analytics', many=True)
 
+    size = serializers.IntegerField(source='fetched_size')
+
 
 class ChannelDetailSerializer(ChannelSerializer):
     """

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -321,7 +321,7 @@ class MediaItemAnalyticsListSerializer(serializers.Serializer):
     A list of media analytics data points.
 
     """
-    results = MediaItemAnalyticsSerializer(source='fetched_analytics', many=True)
+    views_per_day = MediaItemAnalyticsSerializer(source='fetched_analytics', many=True)
 
 
 class ChannelDetailSerializer(ChannelSerializer):

--- a/api/tests/fixtures/mediaitems.yaml
+++ b/api/tests/fixtures/mediaitems.yaml
@@ -65,6 +65,12 @@
     is_public: true
     allows_view_item: a
 
+- model: mediaplatform_jwp.Video
+  pk: jwpvid2
+  fields:
+    updated: 12345
+    item: a
+
 - model: mediaplatform.MediaItem
   pk: empty
   fields:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 # Additional requirements for building documentation
-sphinx
+sphinx<1.8
 sphinx_rtd_theme

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@types/react-router-dom": "^4.3.0",
     "deepmerge": "^2.1.1",
     "hast-util-sanitize": "^1.2.0",
+    "humanize-plus": "^1.8.2",
     "lodash": "^4.17.10",
     "material-ui-chip-input": "^1.0.0-beta.6",
     "moment": "^2.22.2",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -43,6 +43,14 @@ const PROFILE_FROM_PAGE = (
   [0]
 );
 
+// Extract the media item's analytics if it is embedded in the page
+export const ANALYTICS_FROM_PAGE = (
+  Array.from(document.getElementsByTagName('script'))
+  .filter((element: HTMLScriptElement) => element.type === 'application/analytics+json')
+  .map((element: HTMLScriptElement) => JSON.parse(element.text))
+  [0]
+);
+
 /**
  * A function which retrieves a resource from the page by id. Note that, to avoid caching problems,
  * once retrieved, the resource is then removed from the RESOURCES_FROM_PAGE object.

--- a/frontend/src/pages/AnalyticsPage.js
+++ b/frontend/src/pages/AnalyticsPage.js
@@ -9,7 +9,7 @@ import Page from "../containers/Page";
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
-import {mediaGet} from "../api";
+import {mediaGet, ANALYTICS_FROM_PAGE} from "../api";
 import Typography from '@material-ui/core/Typography';
 
 /**
@@ -118,13 +118,17 @@ const withChartData = WrappedComponent => props => {
 
   const summedByDate = {};
 
-  if (window.mediaItemAnalytics.length > 0) {
+  if (
+    ANALYTICS_FROM_PAGE.views_per_day &&
+    ANALYTICS_FROM_PAGE.views_per_day.length > 0
+  ) {
+    const views_per_day = ANALYTICS_FROM_PAGE.views_per_day;
     // Here we sum up all views for a particular day (irrespective of other variable) and
     // calculate the min and max dates.
-    for (let i = 0; i < window.mediaItemAnalytics.length; i ++) {
-      const date = new Date(window.mediaItemAnalytics[i].date);
+    for (let i = 0; i < ANALYTICS_FROM_PAGE.views_per_day.length; i ++) {
+      const date = new Date(ANALYTICS_FROM_PAGE.views_per_day[i].date);
       const views = date in summedByDate ? summedByDate[date] : 0;
-      summedByDate[date] = views + window.mediaItemAnalytics[i].views;
+      summedByDate[date] = views + ANALYTICS_FROM_PAGE.views_per_day[i].views;
       minDate = Math.min(minDate, date);
       maxDate = Math.max(maxDate, date);
     }

--- a/frontend/src/pages/AnalyticsPage.js
+++ b/frontend/src/pages/AnalyticsPage.js
@@ -73,7 +73,7 @@ class AnalyticsPage extends Component {
           <Grid container spacing={16}>
             <Grid item xs={12}>
               <Typography variant="headline" component="div">
-                { mediaItem && mediaItem.name }
+                { mediaItem && mediaItem.title }
               </Typography>
             </Grid>
           </Grid>

--- a/frontend/src/pages/AnalyticsPage.js
+++ b/frontend/src/pages/AnalyticsPage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Humanize from 'humanize-plus';
 
@@ -7,6 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import {Chart} from "react-google-charts";
 import BodySection from '../components/BodySection';
 import Page from "../containers/Page";
+import FetchMediaItem from '../containers/FetchMediaItem';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
@@ -15,121 +16,104 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
-import {mediaGet, ANALYTICS_FROM_PAGE} from "../api";
+import {ANALYTICS_FROM_PAGE} from "../api";
 import Typography from '@material-ui/core/Typography';
 
 /**
  * The media item's analytics page
  */
-class AnalyticsPage extends Component {
+const AnalyticsPage = ({ match: { params: { pk } } }) => (
+  <Page>
+    <FetchMediaItem id={ pk } component={ ConnectedAnalyticsPageContents } />
+  </Page>
+);
 
-  constructor() {
-    super();
-
-    this.state = {
-      // The media item response from the API, if any.
-      mediaItem: null,
-    }
-  }
-
-  componentWillMount() {
-    // As soon as the page mounts, fetch the media item.
-    const { match: { params: { pk } } } = this.props;
-    mediaGet(pk).then(
-      response => this.setState({ mediaItem: response }),
-      error => this.setState({ mediaItem: null })
-    );
-  }
-
-  render() {
-    const { mediaItem } = this.state;
-    const {
-      classes,
-      analytics: { viewsPerDay, size, totalViews },
-      match: { params: { pk } }
-    } = this.props;
-
-    return (
-      <Page>
-        <BodySection classes={{ root: classes.section }}>
-          <Typography variant="headline" component="div">
-            { mediaItem && mediaItem.title }
-          </Typography>
-        </BodySection>
-        <BodySection classes={{ root: classes.section }}>
-          <Typography variant="title" component="div" className={ classes.subtitle } >
-            General Statistics
-          </Typography>
-          <Grid container>
-            <Grid item xs={12} sm={6} md={3} lg={2}>
-              <Paper>
-                <Table>
-                  <TableBody>
-                    <TableRow>
-                      <TableCell>Total Views</TableCell>
-                      <TableCell numeric>{ totalViews }</TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell>Total Size</TableCell>
-                      <TableCell numeric>{ Humanize.fileSize(size) }</TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </Paper>
-            </Grid>
-          </Grid>
-        </BodySection>
-        <BodySection classes={{ root: classes.section }}>
-          <div className={ classes.chartContainer }>
-            <Typography variant="title" component="div" className={ classes.subtitle } >
-              Viewing history (views per day)
+/**
+ * The media item's analytics page contents
+ */
+const AnalyticsPageContents = ({
+  classes,
+  analytics: { viewsPerDay, size, totalViews },
+  resource: mediaItem
+}) => (
+  <div>
+    <BodySection classes={{ root: classes.section }}>
+      <Typography variant="headline" component="div">
+        { mediaItem && mediaItem.title }
+      </Typography>
+    </BodySection>
+    <BodySection classes={{ root: classes.section }}>
+      <Typography variant="title" component="div" className={ classes.subtitle } >
+        General Statistics
+      </Typography>
+      <Grid container>
+        <Grid item xs={12} sm={6} md={3} lg={2}>
+          <Paper>
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Total Views</TableCell>
+                  <TableCell numeric>{ totalViews }</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Total Size</TableCell>
+                  <TableCell numeric>{ Humanize.fileSize(size) }</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Paper>
+        </Grid>
+      </Grid>
+    </BodySection>
+    <BodySection classes={{ root: classes.section }}>
+      <div className={ classes.chartContainer }>
+        <Typography variant="title" component="div" className={ classes.subtitle } >
+          Viewing history (views per day)
+        </Typography>
+        {
+          viewsPerDay.length > 1
+          ?
+            <Typography variant='body1' component='div'>
+              <Chart
+                chartType="AnnotationChart"
+                data={viewsPerDay}
+                options={{fill: 100, colors: ['#EF2E31']}}
+              />
             </Typography>
-            {
-              viewsPerDay.length > 1
-              ?
-                <Typography variant='body1' component='div'>
-                  <Chart
-                    chartType="AnnotationChart"
-                    data={viewsPerDay}
-                    options={{fill: 100, colors: ['#EF2E31']}}
-                  />
-                </Typography>
-              :
-              <Typography variant="subheading">
-                There is no data available for the media
-              </Typography>
+          :
+          <Typography variant="subheading">
+            There is no data available for the media
+          </Typography>
+      }
+      </div>
+    </BodySection>
+    <BodySection classes={{ root: classes.section }}>
+      <Grid container justify='space-between' spacing={16}>
+        <Grid item xs={12} sm={6} md={3} lg={2}/>
+        <Grid item xs={12} sm={6} md={3} lg={2} style={{textAlign: 'right'}}>
+          {
+            mediaItem && mediaItem.legacyStatisticsUrl
+            ?
+            <Button component='a' variant='outlined' className={ classes.link } fullWidth
+              href={mediaItem.legacyStatisticsUrl}
+            >
+              SMS Statistics
+              <ShowChartIcon className={ classes.rightIcon } />
+            </Button>
+            :
+            null
           }
-          </div>
-        </BodySection>
-        <BodySection classes={{ root: classes.section }}>
-          <Grid container justify='space-between' spacing={16}>
-            <Grid item xs={12} sm={6} md={3} lg={2}/>
-            <Grid item xs={12} sm={6} md={3} lg={2} style={{textAlign: 'right'}}>
-              {
-                mediaItem && mediaItem.legacyStatisticsUrl
-                ?
-                <Button component='a' variant='outlined' className={ classes.link } fullWidth
-                  href={mediaItem.legacyStatisticsUrl}
-                >
-                  SMS Statistics
-                  <ShowChartIcon className={ classes.rightIcon } />
-                </Button>
-                :
-                null
-              }
-            </Grid>
-          </Grid>
-        </BodySection>
-      </Page>
-    );
-  }
-}
+        </Grid>
+      </Grid>
+    </BodySection>
+  </div>
+);
 
-AnalyticsPage.propTypes = {
+AnalyticsPageContents.propTypes = {
   analytics: PropTypes.shape({
     size: PropTypes.number,
     totalViews: PropTypes.number,
-    viewsPerDay: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+    viewsPerDay: PropTypes.arrayOf(PropTypes.array),
   }).isRequired,
   classes: PropTypes.object.isRequired,
 };
@@ -232,4 +216,6 @@ var styles = theme => ({
 });
 /* tslint:enable */
 
-export default withAnalytics(withStyles(styles)(AnalyticsPage));
+const ConnectedAnalyticsPageContents = withAnalytics(withStyles(styles)(AnalyticsPageContents));
+
+export default AnalyticsPage;

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -313,11 +313,11 @@ class MediaItem(models.Model):
     @cached_property
     def fetched_size(self):
         """
-        A cached property which returns the storage size of the video in bytes
-        (the sum of all the sources)
+        A cached property which returns the storage size of the video in bytes (the sum of all the
+        sources). Returns 0 if no jwp record is found.
 
         """
-        return self.jwp.fetch_size() if hasattr(self, 'jwp') else []
+        return self.jwp.fetch_size() if hasattr(self, 'jwp') else 0
 
     def get_embed_url(self):
         """

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -302,6 +302,14 @@ class MediaItem(models.Model):
     #: Cached property which calls get_sources() to retrieve sources.
     sources = cached_property(get_sources, name='sources')
 
+    @cached_property
+    def fetched_analytics(self):
+        """
+        A cached property which returns legacy statistics if the media item is a legacy item.
+
+        """
+        return self.sms.fetch_analytics() if hasattr(self, 'sms') else []
+
     def get_embed_url(self):
         """
         Return a URL suitable for use in an IFrame which will render this media. This URL renders

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -310,6 +310,15 @@ class MediaItem(models.Model):
         """
         return self.sms.fetch_analytics() if hasattr(self, 'sms') else []
 
+    @cached_property
+    def fetched_size(self):
+        """
+        A cached property which returns the storage size of the video in bytes
+        (the sum of all the sources)
+
+        """
+        return self.jwp.fetch_size() if hasattr(self, 'jwp') else []
+
     def get_embed_url(self):
         """
         Return a URL suitable for use in an IFrame which will render this media. This URL renders

--- a/mediaplatform/tests/fixtures/test_data.yaml
+++ b/mediaplatform/tests/fixtures/test_data.yaml
@@ -96,6 +96,12 @@
     is_public: true
     allows_view_item: public
 
+- model: mediaplatform_jwp.Video
+  pk: jwpvidpublic
+  fields:
+    updated: 12345
+    item: public
+
 # A media item with a default (allow none) permission
 - model: mediaplatform.MediaItem
   pk: emptyperm

--- a/mediaplatform/tests/test_models.py
+++ b/mediaplatform/tests/test_models.py
@@ -9,6 +9,7 @@ from django.db import IntegrityError
 from django.test import TestCase, override_settings
 
 from legacysms import models as legacymodels
+from mediaplatform_jwp.models import CachedResource
 from .. import models
 
 
@@ -283,6 +284,17 @@ class MediaItemTest(ModelTestCase):
         item.channel.edit_permission.save()
         item.save()
         self.assert_user_can_view(self.user, item)
+
+    def test_fetched_size_success(self):
+        """ check that a size is successfully fetched """
+        CachedResource.objects.create(key='jwpvidpublic', type='video', data={'size': 54321})
+        item = models.MediaItem.objects.get(id='public')
+        self.assertEqual(item.fetched_size, 54321)
+
+    def test_fetched_size_no_jwp(self):
+        """ check that fetched_size doesn't error when the item doesn't have a Video """
+        item = models.MediaItem.objects.get(id='signedin')
+        self.assertEqual(item.fetched_size, 0)
 
     def assert_user_cannot_view(self, user, item_or_id):
         if isinstance(item_or_id, str):

--- a/mediaplatform_jwp/models.py
+++ b/mediaplatform_jwp/models.py
@@ -275,11 +275,12 @@ class Video(models.Model):
 
     def fetch_size(self):
         """
-        Fetches the storage size of the video in bytes (the sum of all the sources)
+        Fetches the storage size of the video in bytes (the sum of all the sources).
+        Returns 0 if unable to get a size.
 
         """
-        data = CachedResource.videos.get(pk=self.pk).data
-        return int(data.get('size', '0'))
+        cache_resource = CachedResource.videos.filter(pk=self.pk).first()
+        return int(({} if cache_resource is None else cache_resource.data).get('size', '0'))
 
     @property
     def embed_url(self):

--- a/mediaplatform_jwp/models.py
+++ b/mediaplatform_jwp/models.py
@@ -273,6 +273,14 @@ class Video(models.Model):
     #: A property which calls get_sources and caches the result.
     sources = cached_property(get_sources, name='sources')
 
+    def fetch_size(self):
+        """
+        Fetches the storage size of the video in bytes (the sum of all the sources)
+
+        """
+        data = CachedResource.videos.get(pk=self.pk).data
+        return int(data.get('size', '0'))
+
     @property
     def embed_url(self):
         """

--- a/mediaplatform_jwp/tests/test_models.py
+++ b/mediaplatform_jwp/tests/test_models.py
@@ -120,3 +120,22 @@ class CachedResourceTest(TestCase):
         self.assertEqual(self.videos.filter(data__x=5).first().key, 'foo')
         self.assertEqual(self.channels.count(), 1)
         self.assertEqual(self.channels.filter(data__z=5).first().key, 'buzz')
+
+
+class VideoTest(TestCase):
+    def setUp(self):
+        self.video = models.Video(key='abc123')
+
+    def test_fetch_size_success(self):
+        """ check that a size is successfully fetched """
+        models.CachedResource.objects.create(key=self.video.pk, type='video', data={'size': 54321})
+        self.assertEqual(self.video.fetch_size(), 54321)
+
+    def test_fetch_size_no_size(self):
+        """ check that a CachedResource with no data.size attribute is handled """
+        models.CachedResource.objects.create(key=self.video.pk, type='video', data={})
+        self.assertEqual(self.video.fetch_size(), 0)
+
+    def test_fetch_size_no_cached_resource(self):
+        """ check that no CachedResource is handled """
+        self.assertEqual(self.video.fetch_size(), 0)

--- a/ui/templates/ui/analytics.html
+++ b/ui/templates/ui/analytics.html
@@ -2,7 +2,7 @@
 {% load to_json %}
 {% block extrabody %}
 {{ block.super }}
-<script>
-  window.mediaItemAnalytics = {% autoescape off %}{{ analytics.results|to_json }}{% endautoescape %};
+<script type="application/analytics+json">
+{{ analytics|to_json }}
 </script>
 {% endblock %}

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -120,7 +120,8 @@ class MediaItemAnalyticsViewTestCase(ViewTestCase):
 
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/analytics.html')
-        self.assertEqual(len(r.context['analytics']['results']), 0)
+        self.assertEqual(len(r.context['analytics']['views_per_day']), 0)
+        self.assertEqual(r.context['analytics']['size'], 0)
 
 
 class IndexViewTestCase(ViewTestCase):


### PR DESCRIPTION
The additional statistics we wished to display were "total number of views", "total storage", & "total streamed". Of these, the "total streamed" was not obviously available in any of the JWP APIs. A support query has been raised with JWP and in the meantime I have implemented the display of the 2 available data points.

Can be reviewed commit wise.
Closes: #196 