### PR TITLE
mediaplatform_jwp: refactor jwpfetch into celery task

### DIFF
--- a/doc/mediaplatform_jwp.rst
+++ b/doc/mediaplatform_jwp.rst
@@ -15,6 +15,12 @@ Models
 .. automodule:: mediaplatform_jwp.models
     :members:
 
+Celery tasks
+------------
+
+.. automodule:: mediaplatform_jwp.tasks
+    :members:
+
 Management commands
 -------------------
 

--- a/mediaplatform_jwp/apps.py
+++ b/mediaplatform_jwp/apps.py
@@ -36,5 +36,5 @@ class Config(AppConfig):
         # Import, and thereby register, our custom signal handlers
         from . import signalhandlers  # noqa: F401
 
-        # Import, and thereby register, out tasks
+        # Import, and thereby register, our tasks
         from . import tasks  # noqa: F401

--- a/mediaplatform_jwp/apps.py
+++ b/mediaplatform_jwp/apps.py
@@ -35,3 +35,6 @@ class Config(AppConfig):
 
         # Import, and thereby register, our custom signal handlers
         from . import signalhandlers  # noqa: F401
+
+        # Import, and thereby register, out tasks
+        from . import tasks  # noqa: F401

--- a/mediaplatform_jwp/management/commands/jwpfetch.py
+++ b/mediaplatform_jwp/management/commands/jwpfetch.py
@@ -24,12 +24,8 @@ only video or channel resources is controlled via the ``--skip-video-fetch`` and
 
 """
 from django.core.management.base import BaseCommand
-from django.db import transaction
 
-from mediaplatform_jwp import models
-from mediaplatform_jwp import sync
-from mediaplatform_jwp.api import delivery as jwplatform
-import mediaplatform.models
+from mediaplatform_jwp import tasks
 
 
 class Command(BaseCommand):
@@ -50,78 +46,9 @@ class Command(BaseCommand):
             '--skip-channel-fetch', action='store_true', dest='skip_channel_fetch',
             help='Do not re-fetch channels from JWP and synchronise with channels')
 
-    @transaction.atomic
     def handle(self, *args, **options):
-        # Create the JWPlatform client
-        self.client = jwplatform.get_jwplatform_client()
-
-        # Fetch and cache the video resources
-        if not options['skip_video_fetch'] and not options['skip_fetch']:
-            self.stdout.write('Caching video resources...')
-            models.set_resources(self.fetch_videos(), 'video')
-
-        # Print out the total number of videos cached
-        self.stdout.write(self.style.SUCCESS('Number of cached video resources: {}'.format(
-            models.CachedResource.videos.count()
-        )))
-
-        if not options['skip_channel_fetch'] and not options['skip_fetch']:
-            self.stdout.write('Fetching channels...')
-            models.set_resources(self.fetch_channels(), 'channel')
-
-        # Print out the total number of channels cached
-        self.stdout.write(self.style.SUCCESS('Number of cached channel resources: {}'.format(
-            models.CachedResource.channels.count()
-        )))
-
-        # Synchronise cached resources into main application state
-        sync.update_related_models_from_cache(update_all_videos=options['sync_all'])
-
-        # Print out the total number of media items
-        self.stdout.write(self.style.SUCCESS('Number of media items: {}'.format(
-            mediaplatform.models.MediaItem.objects.count()
-        )))
-
-        # Print out the total number of channels
-        self.stdout.write(self.style.SUCCESS('Number of channels: {}'.format(
-            mediaplatform.models.Channel.objects.count()
-        )))
-
-    def fetch_videos(self):
-        """
-        Returns an iterable of dicts representing all video resources in the JWPlatform database.
-
-        """
-        return self._fetch_list(self.client.videos.list, 'videos')
-
-    def fetch_channels(self):
-        """
-        Returns an iterable of dicts representing all channel resources in the JWPlatform database.
-
-        """
-        return self._fetch_list(self.client.channels.list, 'channels')
-
-    def _fetch_list(self, list_callable, results_key):
-        """
-        Returns an iterable of dicts representing all resources in the JWPlatform database returned
-        by a given callable.
-
-        """
-        current_offset = 0
-        while True:
-            # We fetch only manual channels since those are the ones we sync via sms2jwplayer.
-            results = list_callable(
-                types_filter='manual',
-                result_offset=current_offset, result_limit=1000).get(results_key, [])
-            current_offset += len(results)
-
-            # Stop when we get no results
-            if len(results) == 0:
-                break
-
-            # Otherwise, print our out progress
-            self.stdout.write(f'... resources fetched so far: {current_offset}')
-
-            # Yield each dict in turn to the caller
-            for result in results:
-                yield result
+        tasks.synchronise(
+            sync_all=options['sync_all'],
+            skip_video_fetch=options['skip_video_fetch'] or options['skip_fetch'],
+            skip_channel_fetch=options['skip_channel_fetch'] or options['skip_fetch']
+        )

--- a/mediaplatform_jwp/tasks.py
+++ b/mediaplatform_jwp/tasks.py
@@ -1,0 +1,114 @@
+"""
+Celery tasks.
+
+"""
+import logging
+
+from celery import shared_task
+from django.db import transaction
+
+from mediaplatform_jwp import models
+from mediaplatform_jwp import sync
+from mediaplatform_jwp.api import delivery as jwplatform
+import mediaplatform.models
+
+
+LOG = logging.getLogger(__name__)
+
+
+@shared_task(name='mediaplatform_jwp.synchronise')
+@transaction.atomic
+def synchronise(sync_all=False, skip_video_fetch=False, skip_channel_fetch=False):
+    """
+    Synchronise the list of Cached JWP resources in the database with the actual list of resources
+    using the JWP management API.
+
+    For JWP videos which come from the SMS, media items are automatically created as videos apear.
+
+    All JWP videos with corresponding media items have basic metadata such as title and description
+    synchronised.
+
+    If *sync_all* is True, all media items are re-synchronised from their corresponding cached JWP
+    resource. If False, only those items whose JWP resources have changed are synchronised.
+
+    If *skip_video_fetch* is True, the cached video resources are not re-fetched from JWP.
+
+    If *skip_channel_fetch* is True, the cached channel resources are not re-fetched from JWP.
+
+    """
+    # Create the JWPlatform client
+    client = jwplatform.get_jwplatform_client()
+
+    # Fetch and cache the video resources
+    if not skip_video_fetch:
+        LOG.info('Caching video resources...')
+        models.set_resources(fetch_videos(client), 'video')
+
+    # Print out the total number of videos cached
+    LOG.info('Number of cached video resources: {}'.format(
+        models.CachedResource.videos.count()
+    ))
+
+    if not skip_channel_fetch:
+        LOG.info('Fetching channels...')
+        models.set_resources(fetch_channels(client), 'channel')
+
+    # Print out the total number of channels cached
+    LOG.info('Number of cached channel resources: {}'.format(
+        models.CachedResource.channels.count()
+    ))
+
+    # Synchronise cached resources into main application state
+    sync.update_related_models_from_cache(update_all_videos=sync_all)
+
+    # Print out the total number of media items
+    LOG.info('Number of media items: {}'.format(
+        mediaplatform.models.MediaItem.objects.count()
+    ))
+
+    # Print out the total number of channels
+    LOG.info('Number of channels: {}'.format(
+        mediaplatform.models.Channel.objects.count()
+    ))
+
+
+def fetch_videos(client):
+    """
+    Returns an iterable of dicts representing all video resources in the JWPlatform database.
+
+    """
+    return _fetch_list(client.videos.list, 'videos')
+
+
+def fetch_channels(client):
+    """
+    Returns an iterable of dicts representing all channel resources in the JWPlatform database.
+
+    """
+    return _fetch_list(client.channels.list, 'channels')
+
+
+def _fetch_list(list_callable, results_key):
+    """
+    Returns an iterable of dicts representing all resources in the JWPlatform database returned
+    by a given callable.
+
+    """
+    current_offset = 0
+    while True:
+        # We fetch only manual channels since those are the ones we sync via sms2jwplayer.
+        results = list_callable(
+            types_filter='manual',
+            result_offset=current_offset, result_limit=1000).get(results_key, [])
+        current_offset += len(results)
+
+        # Stop when we get no results
+        if len(results) == 0:
+            break
+
+        # Otherwise, print our out progress
+        LOG.info(f'... resources fetched so far: {current_offset}')
+
+        # Yield each dict in turn to the caller
+        for result in results:
+            yield result

--- a/mediawebapp/settings/docker.py
+++ b/mediawebapp/settings/docker.py
@@ -63,7 +63,7 @@ LOGGING = {
         },
     },
     'loggers': {
-        'django': {
+        '': {
             'handlers': ['console'],
             'propagate': True,
             'level': 'INFO'


### PR DESCRIPTION
Hoist all the jwpfetch code into a celery task and change the jwpfetch management command to call it.

This removes the need to have a separate jwpfetch cronjob; we can replace it with a scheduled task fixture in the deployment.

This is one half of #296.