### PR TITLE
Add deployment to development as a manual step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,6 @@ jobs:
           path: ~/project/build/doc
           destination: documentation
 
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/doc
-
       - run:
           name: Run codecov
           command: codecov
@@ -85,7 +80,19 @@ jobs:
             else
               echo "Skipping push step as there are no GCloud secrets"
             fi
-  deploy:
+
+      - deploy:
+          name: Save build number (for deploy steps)
+          command: |
+            echo ${CIRCLE_BUILD_NUM} > docker-build_number.txt
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build/doc
+            - docker-build_number.txt
+
+  docs:
     machine: true
     steps:
       - checkout
@@ -95,14 +102,44 @@ jobs:
           name: Deploy to GitHub Pages
           command: ./.circleci/deploy-ghpages.sh ./build/doc
 
+  deploy:
+    machine: true
+    environment:
+      DEPLOY_CIRCLE_PROJECT_USERNAME: 'uisautomation'
+      DEPLOY_CIRCLE_PROJECT_REPONAME: 'media-deploy'
+      DEPLOY_CIRCLE_BRANCH: 'master'
+      DEPLOY_CIRCLECI_JOB_NAME: 'deploy'
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - deploy:
+          name: deploy to development
+          command: |
+            if [ ! -z "$GCLOUD_SERVICE_KEY" ]; then
+              curl --user ${DEPLOY_CIRCLE_API_PROJECT_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=$DEPLOY_CIRCLECI_JOB_NAME \
+                --data build_parameters[IMAGE_TAG]=build-$(cat docker-build_number.txt) \
+                https://circleci.com/api/v1.1/project/github/$DEPLOY_CIRCLE_PROJECT_USERNAME/$DEPLOY_CIRCLE_PROJECT_REPONAME/tree/$DEPLOY_CIRCLE_BRANCH
+            else
+              echo "Skipping deploy as there are no GCloud secrets"
+            fi
+
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       - build
-      - deploy:
+      - docs:
           requires:
-            - build
+          - build
           filters:
             branches:
               only: master
+      - request-deploy:
+          type: approval
+          requires:
+          - build
+      - deploy:
+          requires:
+            - request-deploy


### PR DESCRIPTION
This PR needs to be reviewed in conjunction with https://github.com/uisautomation/media-deploy/pull/51
This PR configures CircleCI to allow a developer to manually trigger a deploy from media-deploy of the image built to the development environment. This PR can be tested before merging to master using the branch `amc203-test-deploy` that will use the branch `deploy-to-development` from media-deploy instead of master: https://circleci.com/gh/uisautomation/workflows/media-webapp/tree/amc203-test-deploy
