### PR TITLE
legacysms: do not redirect back to legacy SMS from embed view

### DIFF
--- a/legacysms/tests/test_views.py
+++ b/legacysms/tests/test_views.py
@@ -47,22 +47,20 @@ class EmbedTest(TestCaseWithFixtures):
 
     def test_no_media(self):
         """
-        Test redirect behaviour when no media is in local cache.
+        Test 404 behaviour when no media is in local cache.
 
         """
         r = self.client.get(reverse('legacysms:embed', kwargs={'media_id': 12345}))
-        self.assertRedirects(r, redirect.media_embed(12345)['Location'],
-                             fetch_redirect_response=False)
+        self.assertEqual(r.status_code, 404)
 
     def test_wrong_media(self):
         """
-        Test redirect behaviour when wrong media returned.
+        Test 404 behaviour when wrong media returned.
 
         """
         # Embedding fails with wrong media id
         r = self.client.get(reverse('legacysms:embed', kwargs={'media_id': 35}))
-        self.assertRedirects(r, redirect.media_embed(35)['Location'],
-                             fetch_redirect_response=False)
+        self.assertEqual(r.status_code, 404)
 
     def test_rss_media(self):
         """

--- a/legacysms/views.py
+++ b/legacysms/views.py
@@ -4,7 +4,7 @@ Django views.
 """
 import logging
 from django.http import Http404, HttpResponse
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 from django.urls import reverse
 import requests
 
@@ -40,9 +40,9 @@ def embed(request, media_id):
         .filter(sms__id=media_id).first()
     )
 
-    # If we can't find the item, redirect back to SMS to see if it knows about it
+    # If we can't find the item, render the custom 404 error page from the api application.
     if item is None:
-        return legacyredirect.media_embed(media_id)
+        return render(request, 'api/embed_404.html', status=404)
 
     return redirect(reverse('api:media_embed', kwargs={'pk': item.id}))
 


### PR DESCRIPTION
Modify the embed view to 404 if a media item is not found rather then try to redirect back to the legacy SMS. We re-use the 404 page from the API embed view which also prompts the user to log in via Raven if they are not currently logged in.

This PR represents, I think, the last change required to be able to enable SMS->media platform redirects for embed views.