### PR TITLE
Update our embed endpoint to use our own code

### DIFF
--- a/api/templates/api/embed_js.html
+++ b/api/templates/api/embed_js.html
@@ -1,0 +1,12 @@
+{% load gtag_script_tag %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{{ media_item.title }}</title>
+    <meta charset="utf-8">
+    {% gtag_script_tag %}
+  </head>
+  <body style="margin: 0">
+    <div id="botr_{{ media_item.jwp.key }}_{{ player_id }}_div"></div>
+    <script src="{{ embed_code }}"></script>
+</body>

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -475,9 +475,9 @@ class MediaItemEmbedTestCase(ViewTestCase):
     def test_basic_functionality(self):
         with mock.patch('time.time') as time:
             time.return_value = 123456
-            expected_url = api.player_embed_url(self.item.jwp.key, 'mock-key', format='html')
+            expected_embed_url = api.player_embed_url(self.item.jwp.key, 'mock-key', format='js')
             response = self.view(self.get_request, pk=self.item.id)
-        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+        self.assertContains(response, '<script src="%s"></script>' % expected_embed_url, html=True)
 
     def test_visibility(self):
         """If an item has no visibility, the embed view should 404."""

--- a/api/views.py
+++ b/api/views.py
@@ -226,13 +226,13 @@ class MediaItemEmbedView(MediaItemMixin, generics.RetrieveAPIView):
 
     def retrieve(self, request, *args, **kwargs):
         item = self.get_object()
-        url = item.get_embed_url()
-
-        # If the item has no associated embed URL, return a 404.
-        if url is None:
+        if not hasattr(item, 'jwp'):
             raise Http404()
-
-        return redirect(url)
+        return render(request, 'api/embed_js.html', {
+            'media_item': item,
+            'embed_code': item.jwp.embed_url(format='js'),
+            'player_id': settings.JWPLATFORM_EMBED_PLAYER_KEY
+        })
 
 
 class MediaItemSourceViewInspector(inspectors.ViewInspector):

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -372,17 +372,6 @@ class MediaItem(models.Model):
             ).get('size', '0')
         )
 
-    def get_jwp_embed_url(self):
-        """
-        Return an URL with an embed view of the media item and player. This comes directly from
-        jwplayer and thus the code inside can't be modified. This URL renders the media
-        unconditionally; it does not respect any view permissions.
-
-        """
-        if not hasattr(self, 'jwp'):
-            return None
-        return self.jwp.embed_url()
-
 
 class Permission(models.Model):
     """

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -370,15 +370,16 @@ class MediaItem(models.Model):
             ).get('size', '0')
         )
 
-    def get_embed_url(self):
+    def get_jwp_embed_url(self):
         """
-        Return a URL suitable for use in an IFrame which will render this media. This URL renders
-        the media unconditionally; it does not respect any view permissions.
+        Return an URL with an embed view of the media item and player. This comes directly from
+        jwplayer and thus the code inside can't be modified. This URL renders the media
+        unconditionally; it does not respect any view permissions.
 
         """
         if not hasattr(self, 'jwp'):
             return None
-        return self.jwp.embed_url
+        return self.jwp.embed_url()
 
 
 class Permission(models.Model):

--- a/mediaplatform_jwp/models.py
+++ b/mediaplatform_jwp/models.py
@@ -277,14 +277,13 @@ class Video(models.Model):
     #: A property which calls get_sources and caches the result.
     sources = cached_property(get_sources, name='sources')
 
-    @property
-    def embed_url(self):
+    def embed_url(self, format='html'):
         """
         Return a URL with an embed view of a :py:class:`mediaplatform.MediaItem`. Returns ``None``
         if there is no JWP video associated with the item.
         """
         return jwplatform.player_embed_url(
-            self.key, settings.JWPLATFORM_EMBED_PLAYER_KEY, format='html'
+            self.key, settings.JWPLATFORM_EMBED_PLAYER_KEY, format=format
         )
 
 


### PR DESCRIPTION
Instead of redirecting to the jwplayer embed code, use our own code, so we can customised it. This PR also solves the problem that the jwplayer embed url does not include google analytics. Because now we are using our own code, we can include it.