### PR TITLE
api: add dedicated endpoint for poster image

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -8,7 +8,7 @@ from django.utils.http import urlencode
 from rest_framework import serializers
 
 from mediaplatform import models as mpmodels
-from mediaplatform_jwp.api import delivery as jwplatform, management as management
+from mediaplatform_jwp.api import management as management
 
 LOG = logging.getLogger(__name__)
 
@@ -198,15 +198,19 @@ class MediaItemSerializer(ChannelOwnedResourceModelSerializer):
         return obj
 
     def get_posterImageUrl(self, obj):
-        if not hasattr(obj, 'jwp'):
-            return None
-        return jwplatform.Video({'key': obj.jwp.key}).get_poster_url(width=640)
+        return self._build_absolute_uri(reverse(
+            'api:media_poster',
+            kwargs={'pk': obj.id, 'width': 720, 'extension': 'jpg'}
+        ))
 
     def get_embedUrl(self, obj):
-        url = reverse('api:media_embed', kwargs={'pk': obj.id})
+        return self._build_absolute_uri(
+            reverse('api:media_embed', kwargs={'pk': obj.id}))
+
+    def _build_absolute_uri(self, uri):
         if 'request' in self.context:
-            url = self.context['request'].build_absolute_uri(url)
-        return url
+            return self.context['request'].build_absolute_uri(uri)
+        return uri
 
 
 # Detail serialisers

--- a/api/urls.py
+++ b/api/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
          name='media_item_analytics'),
     path('media/<pk>/embed', views.MediaItemEmbedView.as_view(), name='media_embed'),
     path('media/<pk>/source', views.MediaItemSourceView.as_view(), name='media_source'),
+    path('media/<pk>/poster-<int:width>.<extension>',
+         views.MediaItemPosterView.as_view(), name='media_poster'),
     path('channels/', views.ChannelListView.as_view(), name='channel_list'),
     path('channels/<pk>', views.ChannelView.as_view(), name='channel'),
     path('playlists/', views.PlaylistListView.as_view(), name='playlist_list'),


### PR DESCRIPTION
Taking a leaf out of the sources endpoint book, add a dedicated API view for the poster image. This allows us to hide JWP URLs so that the backend can change but most users won't notice.

This also allows us to customise the width of the poster images in a more documented way via a width query to the poster image endpoint. JWP only supports a small set of poster images, however, to update the swagger definition and endpoint implementation to know about this.