### PR TITLE
mediaplatform: order playlist media items in the database

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -373,7 +373,7 @@ class PlaylistDetailSerializer(PlaylistSerializer):
 
     channel = ChannelSerializer(read_only=True)
 
-    media = MediaItemSerializer(many=True, source='fetched_media_items_in_order')
+    media = MediaItemSerializer(many=True, source='ordered_media_item_queryset')
 
     class Meta(PlaylistSerializer.Meta):
         fields = PlaylistSerializer.Meta.fields + ('channel', 'media')

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -7,7 +7,7 @@ import automationlookup
 from django.conf import settings
 import django.contrib.postgres.fields as pgfields
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, expressions, functions
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -736,16 +736,25 @@ class Playlist(models.Model):
     #: visible.
     deleted_at = models.DateTimeField(null=True, blank=True)
 
-    @cached_property
-    def fetched_media_items_in_order(self):
-        """Helper method that fetch the playlist's :py:class:`~.MediaItem` objects
-        ordering them as defined by media_items."""
-        media_items_by_id = {
-            item.id: item
-            for item in MediaItem.objects.filter(id__in=self.media_items)
-                .select_related('jwp')
-        }
-        return [media_items_by_id[id] for id in self.media_items if id in media_items_by_id]
+    @property
+    def ordered_media_item_queryset(self):
+        """
+        A queryset which returns the media items for the play list with the same ordering as
+        :py:attr:`.media_items`.
+
+        """
+        all_media_items = (
+            MediaItem.objects
+            .filter(id__in=self.media_items)
+            .annotate(index=expressions.Func(
+                models.Value(self.media_items),
+                functions.Cast(models.F('id'), output_field=models.TextField()),
+                function='array_position'
+            ))
+            .order_by('index')
+        )
+
+        return all_media_items
 
     def __str__(self):
         return '{} ("{}")'.format(self.id, self.title)

--- a/mediaplatform/tests/test_models.py
+++ b/mediaplatform/tests/test_models.py
@@ -799,11 +799,11 @@ class PlaylistTest(ModelTestCase):
         # only 'public' can be viewed
         self.assertEqual(media_items.first().id, 'public')
 
-    def test_fetched_media_items_in_order(self):
-        """The Playlist fetched_media_items_in_order property returns :py:class:`~.MediaItem`
+    def test_ordered_media_item_queryset(self):
+        """The Playlist ordered_media_item_queryset property returns :py:class:`~.MediaItem`
         objects in the correct order and doesn't fail for non-existant items."""
         playlist = models.Playlist.objects.get(id='public')
-        media = playlist.fetched_media_items_in_order
+        media = playlist.ordered_media_item_queryset
         self.assertEqual(len(media), 2)
         self.assertIsInstance(media[0], models.MediaItem)
         self.assertIsInstance(media[1], models.MediaItem)


### PR DESCRIPTION
Add a new property to mediaplatform.models.Playlist, ordered_media_item_queryset, which is a queryset which returns all the media items in the playlist in the same order as they are listed in media_items. This is done in the database rather than in Python so we can additionally filter/modify the queryset after the fact.

This replaces the previous fetched_media_items_in_order property.