### PR TITLE
Stop anonymous media list page being quite so slow to load

### DIFF
--- a/mediaplatform/tests/test_models.py
+++ b/mediaplatform/tests/test_models.py
@@ -166,14 +166,14 @@ class MediaItemTest(ModelTestCase):
         self.assert_user_can_view(self.user, item)
 
     def test_public_item_editable_by_anon(self):
-        """An item with public editable permissions is editable by anonymous."""
+        """An item with public editable permissions is still not editable by anonymous."""
         item = models.MediaItem.objects.get(id='emptyperm')
         self.assert_user_cannot_edit(AnonymousUser(), item)
         self.assert_user_cannot_edit(None, item)
         item.channel.edit_permission.is_public = True
         item.channel.edit_permission.save()
-        self.assert_user_can_edit(AnonymousUser(), item)
-        self.assert_user_can_edit(None, item)
+        self.assert_user_cannot_edit(AnonymousUser(), item)
+        self.assert_user_cannot_edit(None, item)
 
     def test_signed_in_edit_permissions(self):
         """An item with signed in edit permissions is not editable by anonymous."""


### PR DESCRIPTION
As noted in #336, the anonymous media list page is far slower than it really should be. That issue contains some digging on the matter but the executive summary is that querying for related SMS objects in the edit condition is very slow.

The anonymous user should never have an edit permission on anything so, as suggested in #336, a quick win is to shortcut the edit condition check for anonymous users.

This does not completely fix the problem in that non-anonymous views are still slower than they should be.

Testing this change is a little challenging because the pain is only shown for larger databases; a simple GET of https://test.media.cam.ac.uk/api/media/?format=json is taking around 800ms at the moment. By contrast, on development it is around 180ms. With this PR deployed this time drops slightly to 150ms but it is likely that the "win" from this PR will only be seen when deployed to test.