### PR TITLE
compose: add prefix to volume names

### DIFF
--- a/compose/base.yml
+++ b/compose/base.yml
@@ -8,8 +8,8 @@ services:
     env_file:
       - base.env
     volumes:
-      - postgres-data-local:/var/lib/postgresql/data
-      - postgres-backup-local:/backups
+      - media-postgres-data-local:/var/lib/postgresql/data
+      - media-postgres-backup-local:/backups
 
   # Lookup proxy service
   lookupproxy:
@@ -33,8 +33,8 @@ services:
     env_file:
       - lookupproxy.env
     volumes:
-      - lookupproxy-postgres-data-local:/var/lib/postgresql/data
-      - lookupproxy-postgres-backup-local:/backups
+      - media-lookupproxy-postgres-data-local:/var/lib/postgresql/data
+      - media-lookupproxy-postgres-backup-local:/backups
 
   # Hydra OAuth2 infrastructure
   hydra:
@@ -73,15 +73,15 @@ services:
     env_file:
       - hydra.env
     volumes:
-      - hydra-postgres-data-local:/var/lib/postgresql/data
-      - hydra-postgres-backup-local:/backups
+      - media-hydra-postgres-data-local:/var/lib/postgresql/data
+      - media-hydra-postgres-backup-local:/backups
 
 
 volumes:
   # Persistent volumes for postgres database data
-  postgres-data-local:
-  postgres-backup-local:
-  lookupproxy-postgres-data-local:
-  lookupproxy-postgres-backup-local:
-  hydra-postgres-data-local:
-  hydra-postgres-backup-local:
+  media-postgres-data-local:
+  media-postgres-backup-local:
+  media-lookupproxy-postgres-data-local:
+  media-lookupproxy-postgres-backup-local:
+  media-hydra-postgres-data-local:
+  media-hydra-postgres-backup-local:


### PR DESCRIPTION
To avoid collisions with other products in development, make sure that the volume names used by compose (which live in a global namespace) have a unique prefix.