### PR TITLE
Fix 500 errors on channel view

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -484,6 +484,9 @@ class ChannelMixin(ChannelListMixin):
     def get_queryset(self):
         return self.add_channel_detail(super().get_queryset())
 
+    def get_queryset(self):
+        return annotate_channel_qs_for_detail(super().get_queryset(), user=self.request.user)
+
 
 class ChannelListFilterSet(df_filters.FilterSet):
     class Meta:
@@ -519,9 +522,6 @@ class ChannelView(ChannelMixin, generics.RetrieveUpdateAPIView):
 
     """
     serializer_class = serializers.ChannelDetailSerializer
-
-    def get_queryset(self):
-        return annotate_channel_qs_for_detail(super().get_queryset(), user=self.request.user)
 
 
 class PlaylistListMixin(ViewMixinBase):

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -138,3 +138,14 @@ class ChannelViewTestCase(ViewTestCase):
         """A channel page renders."""
         r = self.client.get(reverse('ui:channel', kwargs={'pk': self.channel.id}))
         self.assertEqual(r.status_code, 200)
+
+
+class PlaylistViewTestCase(ViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.playlist = mpmodels.Playlist.objects.get(id='public')
+
+    def test_success(self):
+        """A playlist page renders."""
+        r = self.client.get(reverse('ui:playlist', kwargs={'pk': self.playlist.id}))
+        self.assertEqual(r.status_code, 200)

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
 
+from mediaplatform import models as mpmodels
 import mediaplatform_jwp.api.delivery as api
 from api.tests.test_views import ViewTestCase as _ViewTestCase, DELIVERY_VIDEO_FIXTURE
 
@@ -126,3 +127,14 @@ class IndexViewTestCase(ViewTestCase):
         with self.settings(GTAG_ID=gtag_id):
             r = self.client.get(reverse('ui:home'))
         self.assertIn(gtag_id, r.content.decode('utf8'))
+
+
+class ChannelViewTestCase(ViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.channel = mpmodels.Channel.objects.get(id='channel1')
+
+    def test_success(self):
+        """A channel page renders."""
+        r = self.client.get(reverse('ui:channel', kwargs={'pk': self.channel.id}))
+        self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
The get_queryset specialisation in ChannelView was required for channels to be serialised (unlike the one in MediaItemView which is only required for filtering). Having it in the view and not the mixin meant that the UI view did not annotate the correct information.

This was not found earlier because there was not a test for the channel view in the UI so we add one.

To guard against the same thing happening to PlaylistView which happened to ChannelView, add a basic test for playlists as well.

Closes #339