### PR TITLE
*actually* fix 500 errors for channel view

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -33,43 +33,6 @@ POSTER_IMAGE_DEFAULT_WIDTH = 720
 POSTER_IMAGE_VALID_EXTENSIONS = ['jpg']
 
 
-def get_profile(request):
-    """
-    Return an object representing what is known about a user from a reques. Contains two keys:
-    ``user`` which is simply the user object from the request and ``person`` which is the lookup
-    person resource for the user is non-anoymous.
-
-    """
-    obj = {
-        'user': request.user,
-        'channels': annotate_channel_qs_for_detail(
-            mpmodels.Channel.objects.all().editable_by_user(request.user),
-            user=request.user
-        ),
-    }
-    if not request.user.is_anonymous:
-        try:
-            obj['person'] = automationlookup.get_person(
-                identifier=request.user.username,
-                scheme=getattr(settings, 'LOOKUP_SCHEME', 'crsid'),
-                fetch=['jpegPhoto'],
-            )
-        except requests.HTTPError as e:
-            LOG.warning('Error fetching person: %s', e)
-    return obj
-
-
-class ProfileView(generics.RetrieveAPIView):
-    """
-    Endpoint to retrieve the profile of the current user.
-
-    """
-    serializer_class = serializers.ProfileSerializer
-
-    def get_object(self):
-        return get_profile(self.request)
-
-
 class ListPagination(pagination.CursorPagination):
     page_size = 50
 
@@ -131,14 +94,22 @@ class ViewMixinBase:
         """
         return qs.select_related('channel')
 
-    def add_channel_detail(self, qs):
+    def add_channel_detail(self, qs, name='item_count'):
         """
         Add any extra annotations to a Channel query set which are required to render the detail
         view via ChannelDetailSerializer.
 
         """
-        # Currently this is a no-op
-        return qs
+        items_qs = (
+            self.filter_media_item_qs(mpmodels.MediaItem.objects.all())
+            .filter(channel=models.OuterRef('pk'))
+            .values('channel')
+            .annotate(count=models.Count('*'))
+            .values('count')
+        )
+        return qs.annotate(**{
+            name: models.Subquery(items_qs, output_field=models.BigIntegerField())
+        })
 
     def add_playlist_detail(self, qs):
         """
@@ -163,6 +134,41 @@ class ViewMixinBase:
             .annotate_viewable(self.request.user)
             .annotate_editable(self.request.user)
         )
+
+    def get_profile(self):
+        """
+        Return an object representing what is known about a user from the request. The object can
+        eb serialised with :py:class:`api.serializers.ProfileSerializer`.
+
+        """
+        obj = {
+            'user': self.request.user,
+            'channels': self.add_channel_detail(
+                self.filter_channel_qs(mpmodels.Channel.objects.all())
+                .editable_by_user(self.request.user)
+            ),
+        }
+        if not self.request.user.is_anonymous:
+            try:
+                obj['person'] = automationlookup.get_person(
+                    identifier=self.request.user.username,
+                    scheme=getattr(settings, 'LOOKUP_SCHEME', 'crsid'),
+                    fetch=['jpegPhoto'],
+                )
+            except requests.HTTPError as e:
+                LOG.warning('Error fetching person: %s', e)
+        return obj
+
+
+class ProfileView(ViewMixinBase, generics.RetrieveAPIView):
+    """
+    Endpoint to retrieve the profile of the current user.
+
+    """
+    serializer_class = serializers.ProfileSerializer
+
+    def get_object(self):
+        return self.get_profile()
 
 
 class MediaItemListSearchFilter(filters.SearchFilter):
@@ -520,9 +526,6 @@ class ChannelView(ChannelMixin, generics.RetrieveUpdateAPIView):
     """
     serializer_class = serializers.ChannelDetailSerializer
 
-    def get_queryset(self):
-        return annotate_channel_qs_for_detail(super().get_queryset(), user=self.request.user)
-
 
 class PlaylistListMixin(ViewMixinBase):
     """
@@ -601,19 +604,3 @@ def exception_handler(exc, context):
     }
     new_context.update(context)
     return render(context['request'], 'api/embed_404.html', status=404, context=new_context)
-
-
-def annotate_channel_qs_for_detail(qs, user=None, name='item_count'):
-    """
-    Annotate a queryset returning Channel objects so that they can be serialised by a
-    ChannelDetailSerializer.
-
-    """
-    items_qs = (
-        mpmodels.MediaItem.objects.all().viewable_by_user(user)
-        .filter(channel=models.OuterRef('pk'))
-        .values('channel')
-        .annotate(count=models.Count('*'))
-        .values('count')
-    )
-    return qs.annotate(**{name: models.Subquery(items_qs, output_field=models.BigIntegerField())})

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -3,7 +3,7 @@ import logging
 from django.urls import reverse
 from rest_framework import serializers
 
-from api import serializers as apiserializers, views as apiviews
+from api import serializers as apiserializers
 from mediaplatform_jwp.api import delivery as jwplatform
 
 LOG = logging.getLogger(__name__)
@@ -110,11 +110,7 @@ class ResourcePageSerializer(serializers.Serializer):
     context under the "profile" key.
 
     """
-    profile = serializers.SerializerMethodField()
-
-    def get_profile(self, obj):
-        return apiserializers.ProfileSerializer(
-            apiviews.get_profile(self.context['request']), context=self.context).data
+    profile = apiserializers.ProfileSerializer(read_only=True)
 
 
 class MediaItemPageSerializer(ResourcePageSerializer):

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -138,3 +138,14 @@ class ChannelViewTestCase(ViewTestCase):
         """A channel page renders."""
         r = self.client.get(reverse('ui:channel', kwargs={'pk': self.channel.id}))
         self.assertEqual(r.status_code, 200)
+
+
+class PlaylistViewTestCase(ViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.playlist = mpmodels.Playlist.objects.get(id='public')
+
+    def test_success(self):
+        """A playlist page renders."""
+        r = self.client.get(reverse('ui:playlist', kwargs={'pk': self.playlist.id}))
+        self.assertEqual(r.status_code, 200)

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
 
+from mediaplatform import models as mpmodels
 import mediaplatform_jwp.api.delivery as api
 from api.tests.test_views import ViewTestCase as _ViewTestCase, DELIVERY_VIDEO_FIXTURE
 
@@ -126,3 +127,14 @@ class IndexViewTestCase(ViewTestCase):
         with self.settings(GTAG_ID=gtag_id):
             r = self.client.get(reverse('ui:home'))
         self.assertIn(gtag_id, r.content.decode('utf8'))
+
+
+class ChannelViewTestCase(ViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.channel = mpmodels.Channel.objects.get(id='channel1')
+
+    def test_success(self):
+        """A channel page renders."""
+        r = self.client.get(reverse('ui:channel', kwargs={'pk': self.channel.id}))
+        self.assertEqual(r.status_code, 200)

--- a/ui/views.py
+++ b/ui/views.py
@@ -13,33 +13,41 @@ from . import serializers
 LOG = logging.getLogger(__name__)
 
 
-class MediaView(apiviews.MediaItemMixin, generics.RetrieveAPIView):
+class ResourcePageMixin(apiviews.ViewMixinBase):
+    """
+    Mixin class for views which ensured the returned object is decorated with the current user's
+    profile as required by :py:class:`ui.serializers.ResourcePageSerializer`.
+
+    """
+    renderer_classes = [TemplateHTMLRenderer]
+    template_name = 'ui/resource.html'
+
+    def get_object(self):
+        obj = super().get_object()
+        obj.profile = self.get_profile()
+        return obj
+
+
+class MediaView(ResourcePageMixin, apiviews.MediaItemMixin, generics.RetrieveAPIView):
     """View for rendering an individual media item. Extends the DRF's media item view."""
     serializer_class = serializers.MediaItemPageSerializer
-    renderer_classes = [TemplateHTMLRenderer]
     template_name = 'ui/media.html'
 
 
-class MediaItemAnalyticsView(apiviews.MediaItemMixin, generics.RetrieveAPIView):
+class MediaItemAnalyticsView(ResourcePageMixin, apiviews.MediaItemMixin, generics.RetrieveAPIView):
     """
     View for rendering an individual media item's analytics.
     Extends the DRF's media item analytics view.
 
     """
     serializer_class = serializers.ResourcePageSerializer
-    renderer_classes = [TemplateHTMLRenderer]
-    template_name = 'ui/resource.html'
 
 
-class ChannelView(apiviews.ChannelMixin, generics.RetrieveAPIView):
+class ChannelView(ResourcePageMixin, apiviews.ChannelMixin, generics.RetrieveAPIView):
     """View for rendering an individual channel. Extends the DRF's channel view."""
     serializer_class = serializers.ChannelPageSerializer
-    renderer_classes = [TemplateHTMLRenderer]
-    template_name = 'ui/resource.html'
 
 
-class PlaylistView(apiviews.PlaylistMixin, generics.RetrieveAPIView):
+class PlaylistView(ResourcePageMixin, apiviews.PlaylistMixin, generics.RetrieveAPIView):
     """View for rendering an individual playlist. Extends the DRF's channel view."""
     serializer_class = serializers.PlaylistPageSerializer
-    renderer_classes = [TemplateHTMLRenderer]
-    template_name = 'ui/resource.html'


### PR DESCRIPTION
> This PR supersedes #341 which contained the wrong branch :S.

Commits 5a55d421 and aedbd5a5 attempted to generalise the way that channel objects are annotated for ChannelDetailSerializer. Unfortunately, they generalised it in different ways which meant that, when merged, the generalisation was only applied to the channels rendered as part of the user profile.

Move the ProfileView over to inheriting from ViewMixinBase and teach the latter how to query the current user's profile.

This new method is used both by ProfileView and all of the views in the UI since the profile is rendered as part of each resource page. While we are refactoring, remove the erroneous non-trivial work which is done in the ResourcePageSerializer and place it in the view where it belongs.

The entire UI view/API view interaction is becoming increasingly complex and brittle. We should re-visit the entire way the UI is rendered since we don't *need* to render a corresponding resource or the user profile into the page; we can simply use the API. The only non-trivial view should be the media view since that needs to render structured JSON for SEO purposes.

To guard against the same thing happening to PlaylistView which happened to ChannelView, add a basic test.

Closes #339