### PR TITLE
Additional fields required by itunes for an RSS fields

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -375,9 +375,12 @@ class PlaylistDetailSerializer(PlaylistSerializer):
 
     """
 
+    class Meta(PlaylistSerializer.Meta):
+        fields = PlaylistSerializer.Meta.fields + ('channel', 'mediaForUser')
+
     channel = ChannelSerializer(read_only=True)
 
-    media = MediaItemSerializer(many=True, source='ordered_media_item_queryset')
-
-    class Meta(PlaylistSerializer.Meta):
-        fields = PlaylistSerializer.Meta.fields + ('channel', 'media')
+    mediaForUser = MediaItemSerializer(
+        source='media_for_user', many=True,
+        help_text="List of media resources for this playlist in playlist order."
+    )

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -580,6 +580,17 @@ class MediaItemSourceViewTestCase(ViewTestCase):
         response = self.get()
         self.assertRedirects(response, source['file'], fetch_redirect_response=False)
 
+    def test_extension_ignored(self):
+        """Test that the extension set on the media_source_with_ext endpoint is ignored"""
+        source = DELIVERY_VIDEO_FIXTURE['sources'][0]
+        response = self.client.get(
+            reverse('api:media_source_with_ext', kwargs={
+                'pk': self.item.id,
+                'extension': 'mov'
+            })
+        )
+        self.assertRedirects(response, source['file'], fetch_redirect_response=False)
+
     def test_audio_best_source(self):
         """Best source will include audio if that is all there is."""
         sources = [

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 from unittest import mock
 
 from dateutil import parser as dateparser
@@ -1048,6 +1049,50 @@ class PlaylistViewTestCase(ViewTestCase):
 
     def test_created_at_immutable(self):
         self.assert_field_immutable('createdAt', '2018-08-06T15:29:45.003231Z', 'created_at')
+
+    def test_view_permission_respected(self):
+        """The media items returned in mediaForUser respects view permissions."""
+        playlist = self.playlists.get(id='public')
+
+        # Get a list of all media item ids (included deleted ones) and those viewable by the user.
+        # The lists should differ.
+        all_media_ids = set(
+            m.id for m in mpmodels.MediaItem.objects_including_deleted.all()
+        )
+        viewable_media_ids = set(
+            m.id for m in mpmodels.MediaItem.objects.all().viewable_by_user(self.user)
+        )
+        self.assertGreater(len(all_media_ids), len(viewable_media_ids))
+
+        # The public media item (which is laconically named "a" in the fixtures) should be in both
+        # lists. We'll not add it to the playlist so that we check that the mediaForUser field
+        # doesn't just return *all* media.
+        self.assertIn('a', all_media_ids)
+        self.assertIn('a', viewable_media_ids)
+
+        # More than just the public item is visible.
+        self.assertGreater(len(viewable_media_ids), 1)
+
+        # Form a list of media item ids for the playlist throwing in some ones which do not exist
+        # and set the playlist to have them. We randomly shuffle the list to check that they come
+        # back in the right order.
+        media_items = (
+            [id for id in all_media_ids if id != 'a'] +
+            ['dontexist', 'invalidid']
+        )
+        random.shuffle(media_items)
+        playlist.media_items = media_items
+        playlist.save()
+
+        # From the list of items, form the list we *expect* to get back.
+        expected_ids = [id for id in media_items if id in viewable_media_ids]
+        self.assertGreater(len(expected_ids), 0)
+
+        # Get the response and list of media ids
+        force_authenticate(self.get_request, user=self.user)
+        response = self.view(self.get_request, pk=playlist.id)
+        response_ids = [item['id'] for item in response.data['mediaForUser']]
+        self.assertEqual(response_ids, expected_ids)
 
     def assert_field_mutable(
             self, field_name, new_value='testvalue', model_field_name=None, expected_value=None):

--- a/api/urls.py
+++ b/api/urls.py
@@ -17,6 +17,13 @@ urlpatterns = [
          name='media_item_analytics'),
     path('media/<pk>/embed', views.MediaItemEmbedView.as_view(), name='media_embed'),
     path('media/<pk>/source', views.MediaItemSourceView.as_view(), name='media_source'),
+    # This path is included because itunes doesn't accept an rss feed enclosure url without an
+    # extension. Note that MediaItemSourceView will ignore whatever <extension> is set to and it is
+    # the callers responsibility to ensure that the source type matches the extension.
+    path(
+        'media/<pk>/source.<extension>', views.MediaItemSourceView.as_view(),
+        name='media_source_with_ext'
+    ),
     path('media/<pk>/poster-<int:width>.<extension>',
          views.MediaItemPosterView.as_view(), name='media_poster'),
     path('channels/', views.ChannelListView.as_view(), name='channel_list'),

--- a/api/views.py
+++ b/api/views.py
@@ -540,6 +540,14 @@ class PlaylistMixin(PlaylistListMixin):
     def get_queryset(self):
         return self.add_playlist_detail(super().get_queryset())
 
+    def get_object(self):
+        obj = super().get_object()
+
+        # annotate object with media for user
+        obj.media_for_user = self.filter_media_item_qs(obj.ordered_media_item_queryset)
+
+        return obj
+
 
 class PlaylistListFilterSet(df_filters.FilterSet):
     class Meta:

--- a/frontend/src/pages/PlaylistPage.js
+++ b/frontend/src/pages/PlaylistPage.js
@@ -82,7 +82,7 @@ class PageContent extends Component {
         </Toolbar>
         <RenderedMarkdown source={ playlist.description } />
         <Typography variant='headline' gutterBottom>Media items</Typography>
-        <MediaList resources={playlist.media} />
+        <MediaList resources={playlist.mediaForUser} />
         <DeletePlaylistDialog isOpen={this.state.deleteDialogOpen} title={playlist.title}
                               handleConfirmDelete={this.handleConfirmDelete}/>
       </BodySection>

--- a/legacysms/tests/fixtures/objects.yaml
+++ b/legacysms/tests/fixtures/objects.yaml
@@ -1,0 +1,31 @@
+- model: mediaplatform.Channel
+  pk: chan
+  fields:
+    owning_lookup_inst: DEPTA
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform.Permission
+  pk: chane
+  fields:
+    allows_edit_channel: chan
+
+- model: mediaplatform.Playlist
+  pk: playl
+  fields:
+    channel: chan
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform.Permission
+  pk: playlv
+  fields:
+    is_public: true
+    allows_view_playlist: playl
+
+- model: legacysms.Collection
+  pk: 1234
+  fields:
+    playlist: playl
+    channel: chan
+    last_updated_at: 2010-09-15 14:40:45

--- a/legacysms/urls.py
+++ b/legacysms/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path('downloads/<int:media_id>/<int:clip_id>.<extension>', views.download_media,
          name='download_media'),
     path('media/<int:media_id>/', views.media, name='media'),
+    path('rss/collection/<int:collection_id>/', views.rss_collection, name='rss_collection'),
 ]

--- a/legacysms/views.py
+++ b/legacysms/views.py
@@ -12,6 +12,7 @@ from mediaplatform_jwp.api import delivery as api
 from mediaplatform import models as mpmodels
 
 from . import redirect as legacyredirect
+from . import models
 
 
 LOG = logging.getLogger(__name__)
@@ -192,6 +193,16 @@ def media(request, media_id):
     return redirect(reverse('ui:media_item', kwargs={'pk': item.id}))
 
 
+def rss_collection(request, collection_id):
+    playlist = _find_collection_playlist(collection_id, request)
+
+    # If we can't find the playlist, raise a 404.
+    if playlist is None:
+        raise Http404()
+
+    return redirect(reverse('ui:playlist_rss', kwargs={'pk': playlist.id}))
+
+
 def _find_media_item(media_id, request):
     """
     Locates a media item for the passed SMS media id for the user in the passed request. If no such
@@ -201,4 +212,20 @@ def _find_media_item(media_id, request):
     return (
         mpmodels.MediaItem.objects.all().viewable_by_user(request.user)
         .filter(sms__id=media_id).first()
+    )
+
+
+def _find_collection_playlist(collection_id, request):
+    """
+    Locates a playlist for the passed SMS collection id for the user in the passed request. If no
+    such playlist can be found, return None.
+
+    """
+    collection = models.Collection.objects.filter(id=collection_id).first()
+    if collection is None:
+        return None
+
+    return (
+        mpmodels.Playlist.objects.all().viewable_by_user(request.user)
+        .filter(id=collection.playlist.id).first()
     )

--- a/mediaplatform/tests/fixtures/test_data.yaml
+++ b/mediaplatform/tests/fixtures/test_data.yaml
@@ -17,6 +17,21 @@
   fields:
     allows_edit_channel: channel1
 
+- model: mediaplatform_jwp.Channel
+  pk: jwpchannel1
+  fields:
+    updated: 12345
+    channel: channel1
+    resource: crjwpchannel1
+
+- model: mediaplatform_jwp.CachedResource
+  pk: crjwpchannel1
+  fields:
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+    data:
+      author: "J. M. Barrie"
+
 # Deleted channel
 - model: mediaplatform.Channel
   pk: delchan
@@ -109,6 +124,8 @@
     data:
       keu: publicvid
       status: ready
+      author: "J. M. Barrie"
+      size: 54321
 
 - model: mediaplatform_jwp.Video
   pk: jwpvidpublic

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,9 @@ django-reversion
 # For loading fixtures
 PyYAML
 
+# rss feed generator
+feedgen
+
 # PRE-RELEASE WHITENOISE VERSION
 # We need at least version 4 of whitenoise to make use of the index_file
 # configuration option.

--- a/ui/renderers.py
+++ b/ui/renderers.py
@@ -1,6 +1,9 @@
 from feedgen.feed import FeedGenerator
 from rest_framework import renderers
 
+# if no author is set for the item or channel this default is used
+DEFAULT_AUTHOR = 'Cambridge University'
+
 
 class RSSRenderer(renderers.BaseRenderer):
     """
@@ -58,10 +61,13 @@ class RSSRenderer(renderers.BaseRenderer):
         fg.description(_ensure_non_empty(data['description']))
         fg.podcast.itunes_summary(_ensure_non_empty(data['description']))
 
+        # The author.
+        fg.podcast.itunes_author(data['author'] if data['author'] else DEFAULT_AUTHOR)
+
         # Self link.
         fg.link(href=data['url'])
 
-        # TODO: Missing fields from playlists: author, contributors, logo, subtitle, and language.
+        # TODO: Missing fields from playlists: contributors, logo, subtitle, and language.
 
         # Add entries
         for entry in data['entries']:
@@ -75,6 +81,9 @@ class RSSRenderer(renderers.BaseRenderer):
             fe.title(entry['title'])
             fe.description(_ensure_non_empty(entry['description']))
             fe.summary(_ensure_non_empty(entry['description']))
+
+            # The author.
+            fe.podcast.itunes_author(entry['author'] if entry['author'] else DEFAULT_AUTHOR)
 
             # RSS only supports one link with nothing but a URL. So for the RSS link element the
             # last link with rel=alternate is used. We link to the UI view even though we use the

--- a/ui/renderers.py
+++ b/ui/renderers.py
@@ -1,0 +1,112 @@
+from feedgen.feed import FeedGenerator
+from rest_framework import renderers
+
+
+class RSSRenderer(renderers.BaseRenderer):
+    """
+    A specialised renderer for RSS feeds which match the iTunes RSS feed specification
+    at https://help.apple.com/itc/podcasts_connect/#/itc1723472cb.
+
+    Expects that the data is of the following form:
+
+    .. code:: python
+
+        {
+            'url': str,  # link back to resource
+            'title': str,
+            'description': str,
+            'entries': [
+                'url': str,
+                'imageUrl': str,  # must end in .jpg or .png
+                'title': str,
+                'description': str,
+                'duration': int,  # in seconds
+                'rights': str,
+                'published_at': datetime,
+                'updated_at': datetime,
+                'enclosures': [
+                    {
+                        'url': str,
+                        'mime_type': str,
+                    }, # ...
+                ],
+            ],
+        }
+
+    """
+    media_type = 'application/rss+xml'
+    format = 'rss'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        renderer_context = renderer_context or {}
+        response = renderer_context['response']
+
+        if response.exception:
+            return f'Error: {response.status_code}'
+
+        # If we get this far, the response is not an error and we can render the RSS feed.
+
+        # Prepare the feed generator object.
+        fg = FeedGenerator()
+        fg.load_extension('podcast')
+
+        # Playlist wrapper.
+        fg.id(data['url'])
+        fg.title(data['title'])
+
+        # Description. Feedgen will raise exception if the description is empty
+        fg.description(_ensure_non_empty(data['description']))
+        fg.podcast.itunes_summary(_ensure_non_empty(data['description']))
+
+        # Self link.
+        fg.link(href=data['url'])
+
+        # TODO: Missing fields from playlists: author, contributors, logo, subtitle, and language.
+
+        # Add entries
+        for entry in data['entries']:
+            fe = fg.add_entry()
+
+            # The item id. We don't set permaLink for the moment because URLs may change during the
+            # alpha.
+            fe.id(entry['url'])
+
+            # Set basic metadata. Feedgen will raise an exception if the description is empty.
+            fe.title(entry['title'])
+            fe.description(_ensure_non_empty(entry['description']))
+            fe.summary(_ensure_non_empty(entry['description']))
+
+            # RSS only supports one link with nothing but a URL. So for the RSS link element the
+            # last link with rel=alternate is used. We link to the UI view even though we use the
+            # API endpoint as the id.
+            fe.link(href=entry['url'])
+
+            # Publication date.
+            fe.pubDate(entry['published_at'])
+
+            # Free-text copyright field.
+            fe.rights(entry['rights'])
+
+            # When the item was last updated.
+            fe.updated(entry['updated_at'])
+
+            # Image. Note: iTunes *requires* this to end in ".jpg" or ".png" which is annoying.
+            fe.podcast.itunes_image(entry['imageUrl'])
+
+            # Duration in seconds.
+            fe.podcast.itunes_duration(entry['duration'])
+
+            # The actual downloads themselves.
+            for enclosure in entry['enclosures']:
+                fe.enclosure(url=enclosure['url'], type=enclosure['mime_type'])
+
+        # Render the feed.
+        return fg.rss_str(pretty=True)
+
+
+def _ensure_non_empty(s):
+    """
+    Take a str or None and return a non-empty string.
+
+    """
+    return ' ' if s is None or s == '' else s

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -134,6 +134,7 @@ class MediaItemRSSEntitySerializer(serializers.Serializer):
     imageUrl = serializers.SerializerMethodField()
     title = serializers.CharField()
     description = serializers.CharField()
+    author = serializers.CharField(source='fetched_author')
     duration = serializers.IntegerField()
     rights = serializers.CharField(source='copyright')
     published_at = serializers.DateTimeField()
@@ -177,6 +178,7 @@ class MediaItemRSSSerializer(serializers.Serializer):
     url = serializers.HyperlinkedIdentityField(view_name='ui:media_item_rss')
     title = serializers.CharField()
     description = serializers.CharField()
+    author = serializers.CharField(source='fetched_author')
     entries = MediaItemRSSEntitySerializer(many=True, source='self_list')
 
 
@@ -213,4 +215,5 @@ class PlaylistRSSSerializer(serializers.Serializer):
     url = serializers.HyperlinkedIdentityField(view_name='ui:playlist_rss')
     title = serializers.CharField()
     description = serializers.CharField()
+    author = serializers.CharField(source='channel.fetched_author')
     entries = MediaItemRSSEntitySerializer(many=True, source='downloadable_media_items')

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -201,3 +201,14 @@ class MediaItemAnalyticsPageSerializer(ResourcePageSerializer):
     """
     resource = apiserializers.MediaItemDetailSerializer(source='*')
     analytics = apiserializers.MediaItemAnalyticsListSerializer(source='*')
+
+
+class PlaylistRSSSerializer(serializers.Serializer):
+    """
+    Serialise a playlist resource into data suitable for :py:class:`ui.renderers.RSSRenderer`.
+
+    """
+    url = serializers.HyperlinkedIdentityField(view_name='ui:playlist_rss')
+    title = serializers.CharField()
+    description = serializers.CharField()
+    entries = MediaItemRSSEntitySerializer(many=True, source='downloadable_media_items')

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -151,9 +151,15 @@ class MediaItemRSSEntitySerializer(serializers.Serializer):
         # "sources" attribute requires a call to the JWP delivery API and may be too expensive/slow
         # if there are large numbers of media items. In the future, if sources are cached in the
         # database, we can do this "properly".
+        mime_type = MIME_TYPE_MAPPING.get(obj.type, 'application/octet-stream')
+        # Unfortunately itunes requires a url with an extension so we have to use
+        # media_source_with_ext here.
         return [{
-            'url': self._absolute_uri(reverse('api:media_source', kwargs={'pk': obj.id})),
-            'mime_type': MIME_TYPE_MAPPING.get(obj.type, 'application/octet-stream')
+            'url': self._absolute_uri(reverse('api:media_source_with_ext', kwargs={
+                'pk': obj.id,
+                'extension': mime_type.split('/')[1]
+            })),
+            'mime_type': mime_type
         }]
 
     def _absolute_uri(self, uri):

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -6,10 +6,11 @@ from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, Permission
 from django.test import override_settings
 from django.urls import reverse
 
+import mediaplatform.models as mpmodels
 import mediaplatform_jwp.api.delivery as api
 from api.tests.test_views import ViewTestCase as _ViewTestCase, DELIVERY_VIDEO_FIXTURE
 
@@ -127,3 +128,108 @@ class IndexViewTestCase(ViewTestCase):
         with self.settings(GTAG_ID=gtag_id):
             r = self.client.get(reverse('ui:home'))
         self.assertIn(gtag_id, r.content.decode('utf8'))
+
+
+class MediaRSSViewTestCase(ViewTestCase):
+    def setUp(self):
+        self.lookup_groupids_and_instids_for_user_patcher = mock.patch(
+                'mediaplatform.models._lookup_groupids_and_instids_for_user')
+        self.lookup_groupids_and_instids_for_user = (
+            self.lookup_groupids_and_instids_for_user_patcher.start())
+        self.lookup_groupids_and_instids_for_user.return_value = ([], [])
+        self.addCleanup(self.lookup_groupids_and_instids_for_user_patcher.stop)
+
+        # Make sure there is a public downloadable item to render
+        self.item = mpmodels.MediaItem.objects.get(id='populated')
+        self.item.view_permission.reset()
+        self.item.view_permission.is_public = True
+        self.item.view_permission.save()
+        self.item.downloadable = True
+        self.item.save()
+
+        self.new_user = get_user_model().objects.create(username='newuser')
+
+    def test_success(self):
+        """A downloadable viewable media item renders a RSS feed."""
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(self.item.title, r.content.decode('utf-8'))
+
+    def test_non_downloadable(self):
+        """A non-downloadable item results in a 404."""
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 200)
+        self.item.downloadable = False
+        self.item.save()
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 404)
+
+    def test_super_downloader(self):
+        """A user with mediaplatform.download_mediaitem permission can always download."""
+        self.item.downloadable = False
+        self.item.save()
+        self.client.force_login(self.new_user)
+
+        # initially cannot see the item
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 404)
+
+        # add the permission to the user
+        view_permission = Permission.objects.get(
+            codename='download_mediaitem', content_type__app_label='mediaplatform')
+        self.new_user.user_permissions.add(view_permission)
+        self.new_user.save()
+
+        # can now see the item
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 200)
+
+    def test_non_visible(self):
+        """A non-visible item results in a 404."""
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 200)
+        self.item.view_permission.reset()
+        self.item.view_permission.save()
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 404)
+
+    def test_super_viewer(self):
+        """A user with mediaplatform.view_mediaitem permission can always view if download set."""
+        self.item.view_permission.reset()
+        self.item.view_permission.save()
+        self.client.force_login(self.new_user)
+
+        # initially cannot see the item
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 404)
+
+        # add the permission to the user
+        view_permission = Permission.objects.get(
+            codename='view_mediaitem', content_type__app_label='mediaplatform')
+        self.new_user.user_permissions.add(view_permission)
+        self.new_user.save()
+
+        # can now see the item
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 200)
+
+        # remove downloadable
+        self.item.downloadable = False
+        self.item.save()
+
+        # cannot see the item any more
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 404)
+
+    def test_non_sms(self):
+        """A media item not visible unless it came from the SMS."""
+        # initially OK
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 200)
+
+        # delete related SMS objed
+        self.item.sms.delete()
+
+        # should not be visible
+        r = self.client.get(reverse('ui:media_item_rss', kwargs={'pk': self.item.pk}))
+        self.assertEqual(r.status_code, 404)

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -33,10 +33,11 @@ urlpatterns = [
         login_required(TemplateView.as_view(template_name="ui/media_item_new.html")),
         name='media_item_new'
     ),
-    path('media/<pk>/analytics', views.MediaItemAnalyticsView.as_view(),
+    path('media/<slug:pk>/analytics', views.MediaItemAnalyticsView.as_view(),
          name='media_item_analytics'),
-    path('media/<pk>/edit', views.MediaView.as_view(), name='media_item_edit'),
-    path('media/<pk>', views.MediaView.as_view(), name='media_item'),
+    path('media/<slug:pk>/edit', views.MediaView.as_view(), name='media_item_edit'),
+    path('media/<slug:pk>', views.MediaView.as_view(), name='media_item'),
+    path('media/<slug:pk>.rss', views.MediaItemRSSView.as_view(), name='media_item_rss'),
     path('channels/<pk>', views.ChannelView.as_view(), name='channel'),
     path(
         'playlists/new',

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -44,8 +44,9 @@ urlpatterns = [
         login_required(TemplateView.as_view(template_name="ui/playlist_new.html")),
         name='playlist_new'
     ),
-    path('playlists/<pk>', views.PlaylistView.as_view(), name='playlist'),
-    path('playlists/<pk>/edit', views.PlaylistView.as_view(), name='playlist_edit'),
+    path('playlists/<slug:pk>', views.PlaylistView.as_view(), name='playlist'),
+    path('playlists/<slug:pk>.rss', views.PlaylistRSSView.as_view(), name='playlist_rss'),
+    path('playlists/<slug:pk>/edit', views.PlaylistView.as_view(), name='playlist_edit'),
     path('about', TemplateView.as_view(template_name="ui/about.html"), name='about'),
     path('changelog', TemplateView.as_view(
         template_name="ui/changelog.html", extra_context={'changelog': changelog}

--- a/ui/views.py
+++ b/ui/views.py
@@ -8,6 +8,8 @@ from rest_framework import generics
 from rest_framework.renderers import TemplateHTMLRenderer
 
 from api import views as apiviews
+
+from . import renderers
 from . import serializers
 
 LOG = logging.getLogger(__name__)
@@ -18,6 +20,33 @@ class MediaView(apiviews.MediaItemMixin, generics.RetrieveAPIView):
     serializer_class = serializers.MediaItemPageSerializer
     renderer_classes = [TemplateHTMLRenderer]
     template_name = 'ui/media.html'
+
+
+class MediaItemRSSView(apiviews.MediaItemMixin, generics.RetrieveAPIView):
+    """
+    Retrieve an individual media item as RSS.
+
+    IMPORTANT: we do not want this sort of feed to proliferate and so it is only available for
+    media items which were imported from the old SMS.
+
+    """
+    # We cannot simply make use of the normal DRF content negotiation and format_suffix_patterns()
+    # because this results in an additional "format" parameter being passed to the class which is
+    # then used to reverse() URLs for hyperlinked resources such as channels. Since none of those
+    # views support the format parameter, the reverse() call used by HyperlinkedIdentityField
+    # fails.
+    renderer_classes = [renderers.RSSRenderer]
+    serializer_class = serializers.MediaItemRSSSerializer
+
+    def get_queryset(self):
+        return super().get_queryset().filter(downloadable_by_user=True, sms__isnull=False)
+
+    def get_object(self):
+        obj = super().get_object()
+        # We need to render a list of entries with just this media item as a single entry. This is
+        # a bit of a hacky way of doing this but it works.
+        obj.self_list = [obj]
+        return obj
 
 
 class MediaItemAnalyticsView(apiviews.MediaItemMixin, generics.RetrieveAPIView):

--- a/ui/views.py
+++ b/ui/views.py
@@ -72,3 +72,25 @@ class PlaylistView(apiviews.PlaylistMixin, generics.RetrieveAPIView):
     serializer_class = serializers.PlaylistPageSerializer
     renderer_classes = [TemplateHTMLRenderer]
     template_name = 'ui/resource.html'
+
+
+class PlaylistRSSView(apiviews.PlaylistMixin, generics.RetrieveAPIView):
+    """
+    Retrieve an individual playlist as RSS.
+
+    """
+    # We cannot simply make use of the normal DRF content negotiation and format_suffix_patterns()
+    # because this results in an additional "format" parameter being passed to the class which is
+    # then used to reverse() URLs for hyperlinked resources such as channels. Since none of those
+    # views support the format parameter, the reverse() call used by HyperlinkedIdentityField
+    # fails.
+    renderer_classes = [renderers.RSSRenderer]
+    serializer_class = serializers.PlaylistRSSSerializer
+
+    def get_object(self):
+        obj = super().get_object()
+        obj.downloadable_media_items = (
+            self.filter_media_item_qs(obj.ordered_media_item_queryset)
+            .downloadable_by_user(self.request.user)
+        )
+        return obj


### PR DESCRIPTION
This PR addresses the additional fields required by itunes for an RSS fields. Commit `508f516` addresses the need for a type extension on the source url. Commit `ced62cb` addresses the need for an author in the channel and item.

This PR follows from uisautomation/media-webapp/pull/335.

closes: #347 