### PR TITLE
add project name to docker-compose

### DIFF
--- a/compose.sh
+++ b/compose.sh
@@ -27,4 +27,5 @@ fi
 cd "$( dirname "${BASH_SOURCE[0]}")"
 
 set -x
-exec docker-compose --file compose/base.yml --file compose/${config}.yml $args
+exec docker-compose --project-name media \
+  --file compose/base.yml --file compose/${config}.yml $args

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -8,8 +8,8 @@ services:
     env_file:
       - base.env
     volumes:
-      - media-postgres-data-local:/var/lib/postgresql/data
-      - media-postgres-backup-local:/backups
+      - postgres-data-local:/var/lib/postgresql/data
+      - postgres-backup-local:/backups
 
   # Lookup proxy service
   lookupproxy:
@@ -33,8 +33,8 @@ services:
     env_file:
       - lookupproxy.env
     volumes:
-      - media-lookupproxy-postgres-data-local:/var/lib/postgresql/data
-      - media-lookupproxy-postgres-backup-local:/backups
+      - lookupproxy-postgres-data-local:/var/lib/postgresql/data
+      - lookupproxy-postgres-backup-local:/backups
 
   # Hydra OAuth2 infrastructure
   hydra:
@@ -73,15 +73,15 @@ services:
     env_file:
       - hydra.env
     volumes:
-      - media-hydra-postgres-data-local:/var/lib/postgresql/data
-      - media-hydra-postgres-backup-local:/backups
+      - hydra-postgres-data-local:/var/lib/postgresql/data
+      - hydra-postgres-backup-local:/backups
 
 
 volumes:
   # Persistent volumes for postgres database data
-  media-postgres-data-local:
-  media-postgres-backup-local:
-  media-lookupproxy-postgres-data-local:
-  media-lookupproxy-postgres-backup-local:
-  media-hydra-postgres-data-local:
-  media-hydra-postgres-backup-local:
+  postgres-data-local:
+  postgres-backup-local:
+  lookupproxy-postgres-data-local:
+  lookupproxy-postgres-backup-local:
+  hydra-postgres-data-local:
+  hydra-postgres-backup-local:


### PR DESCRIPTION
docker-compose uses the project name as a prefix for all Docker resources it creates. This defaults to the name of the directory holding the compose file. This is not great in our use case because all our compose files live inside a directory named "compose". Specify the docker-compose project name explicitly in the ./compose.sh wrapper.