### PR TITLE
work around django-celery-beat bug

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,5 +48,5 @@ gunicorn
 
 # Task runner
 celery<5
-django-celery-beat
+django-celery-beat<1.2.0
 django-celery-results


### PR DESCRIPTION
> **IMPORTANT** This PR is intended to address an issue which is currently affecting production.

Release 1.2.0 of django-celery-beat had a [bug](https://github.com/celery/django-celery-beat/issues/158) whereby a race condition could cause the scheduler to get confused and stop scheduling jobs.

We were observing the same "connection already closed" errors from psycopg2 when 1.2.0 was deployed so pin the version of django-celery-beat to a pre 1.2.0 release.

I deployed this fix to development and test and in both cases the scheduler became unstuck and jwpfetch jobs started again.

I wonder if this is a sign we should start pip freezing and storing the resulting file in the source tree like we do with npm and package.lock. That way we can choose when we upgrade rather than getting future surprises like this.