### PR TITLE
API: allow specifying page size

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -36,6 +36,7 @@ POSTER_IMAGE_VALID_EXTENSIONS = ['jpg']
 
 class ListPagination(pagination.CursorPagination):
     page_size = 50
+    page_size_query_param = 'page_size'
 
 
 class FullTextSearchFilter(filters.SearchFilter):

--- a/api/views.py
+++ b/api/views.py
@@ -37,6 +37,7 @@ POSTER_IMAGE_VALID_EXTENSIONS = ['jpg']
 class ListPagination(pagination.CursorPagination):
     page_size = 50
     page_size_query_param = 'page_size'
+    max_page_size = 300
 
 
 class FullTextSearchFilter(filters.SearchFilter):


### PR DESCRIPTION
This PR breaks out the page size changes from #358 since they are usable on their own. We also configure a maximum page size of (arbitrarily) 300 items.