### PR TITLE
replace legacy download with redirect to new site

### DIFF
--- a/legacysms/tests/test_views.py
+++ b/legacysms/tests/test_views.py
@@ -2,23 +2,19 @@
 Tests for views.
 
 """
-import copy
 from contextlib import contextmanager
 from unittest import mock
 
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import TestCase
-import requests
 
-import mediaplatform_jwp.api.delivery as api
 from mediaplatform_jwp.models import CachedResource
 from mediaplatform import models as mpmodels
 from mediaplatform_jwp import sync
 
 from .. import models
 from .. import redirect
-from .. import views
 
 
 class TestCaseWithFixtures(TestCase):
@@ -97,178 +93,27 @@ class RSSMediaTestCase(TestCaseWithFixtures):
         self.assertEqual(r.status_code, 404)
 
 
-class DownloadTests(TestCase):
+class DownloadTests(TestCaseWithFixtures):
     """
     Test media download functionality.
 
     """
 
-    def setUp(self):
-        # Patch the video_from_media_id call
-        self.video_from_media_id_patcher = mock.patch(
-            'mediaplatform_jwp.api.delivery.Video.from_media_id')
-
-        # Patch the requests library
-        self.requests_session_patcher = mock.patch('legacysms.views.DEFAULT_REQUESTS_SESSION')
-
-        self.video_from_media_id = self.video_from_media_id_patcher.start()
-        self.requests_session = self.requests_session_patcher.start()
-
-        # Video.from_media_id() by default returns a mock Video resource
-        self.mock_video = api.Video({'key': 'video-key'})
-        self.video_from_media_id.return_value = self.mock_video
-
-    def tearDown(self):
-        # Stop patching
-        self.video_from_media_id_patcher.stop()
-        self.requests_session_patcher.stop()
-
     def test_basic_functionality(self):
         """Basic redirection functionality works."""
-        self.requests_session.get.return_value.json.return_value = MEDIA_INFO
-
         r = self.client.get(reverse('legacysms:download_media',
                                     kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
+        item = mpmodels.MediaItem.objects.get(sms__id=34)
 
-        self.assertRedirects(r, 'http://media.invalid/2.mp4', fetch_redirect_response=False)
+        self.assertRedirects(
+            r, reverse('api:media_source', kwargs={'pk': item.id}),
+            fetch_redirect_response=False)
 
-    def test_passes_video_key_to_jwp(self):
-        """The correct video key used to get video info."""
-        with mock.patch('time.time', return_value=12345):
-            self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-
-            self.requests_session.get.assert_called_once_with(
-                api.pd_api_url(f'/v2/media/video-key', format='json'), timeout=5
-            )
-
-    def test_redirects_if_not_found(self):
-        """Redirects to legacy SMS if video is not present."""
-        self.video_from_media_id.side_effect = api.VideoNotFoundError()
-
+    def test_404_if_not_found(self):
+        """Returns a 404 response if video is not present."""
         r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-
-        self.assertRedirects(r, redirect.media_download(34, 56, 'mp4')['Location'],
-                             fetch_redirect_response=False)
-
-    def test_bad_gateway_if_timeout(self):
-        """If request times out, a bad gateway error is returned."""
-        self.requests_session.get.side_effect = requests.Timeout()
-
-        # Check that a warning is also logged
-        with self.assertLogs(views.LOG, 'WARNING'):
-            r = self.client.get(reverse(
-                'legacysms:download_media',
-                kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-
-        self.assertEqual(r.status_code, 502)
-
-    def test_bad_gateway_if_upstream_error(self):
-        """If request to JWPlayer gives HTTP error, a bad gateway error is returned."""
-        self.requests_session.get.return_value.raise_for_status.side_effect = requests.HTTPError()
-
-        # Check that a warning is also logged
-        with self.assertLogs(views.LOG, 'WARNING'):
-            r = self.client.get(reverse(
-                'legacysms:download_media',
-                kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-
-        self.assertEqual(r.status_code, 502)
-
-    def test_bad_gateway_if_bad_json(self):
-        """If request to JWPlayer gives un-parseable JSON, a bad gateway error is returned."""
-        self.requests_session.get.return_value.json.side_effect = Exception()
-
-        # Check that a warning is also logged
-        with self.assertLogs(views.LOG, 'WARNING'):
-            r = self.client.get(reverse(
-                'legacysms:download_media',
-                kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-
-        self.assertEqual(r.status_code, 502)
-
-    def test_redirects_if_no_playlist(self):
-        """Redirects to legacy SMS if there is no playlist or an empty playlist."""
-        # No playlist
-        self.requests_session.get.return_value.json.return_value = {}
-        r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-        self.assertRedirects(r, redirect.media_download(34, 56, 'mp4')['Location'],
-                             fetch_redirect_response=False)
-
-        # Empty playlist
-        self.requests_session.get.return_value.json.return_value = {'playlist': []}
-        r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-        self.assertRedirects(r, redirect.media_download(34, 56, 'mp4')['Location'],
-                             fetch_redirect_response=False)
-
-    def test_redirects_if_no_sources(self):
-        """Redirects to legacy SMS if there are no sources."""
-        # No sources
-        self.requests_session.get.return_value.json.return_value = {'playlist': [{}]}
-        r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-        self.assertRedirects(r, redirect.media_download(34, 56, 'mp4')['Location'],
-                             fetch_redirect_response=False)
-
-        # Empty sources
-        self.requests_session.get.return_value.json.return_value = {'playlist': [{'sources': []}]}
-        r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-        self.assertRedirects(r, redirect.media_download(34, 56, 'mp4')['Location'],
-                             fetch_redirect_response=False)
-
-    def test_404_if_bad_extension(self):
-        """404 is returned if an unknown extension is given"""
-        self.requests_session.get.return_value.json.return_value = MEDIA_INFO
-
-        r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension':
-                                            'not-a-video'}))
-
+                                    kwargs={'media_id': 3456, 'clip_id': 56, 'extension': 'mp4'}))
         self.assertEqual(r.status_code, 404)
-
-    def test_redirects_if_no_file(self):
-        """Redirects to legacy SMS if the source has no file set."""
-        media_info = copy.deepcopy(MEDIA_INFO)
-        media_info['playlist'][0]['sources'] = [
-            {'width': 1280, 'height': 720, 'type': 'video/mp4'}
-        ]
-
-        self.requests_session.get.return_value.json.return_value = media_info
-        r = self.client.get(reverse('legacysms:download_media',
-                                    kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-        self.assertRedirects(r, redirect.media_download(34, 56, 'mp4')['Location'],
-                             fetch_redirect_response=False)
-
-    def test_no_permission(self):
-        """
-        Tests the behaviour when the user's identity (if any) doesn't match the ACL.
-
-        """
-        with mock.patch('mediaplatform_jwp.api.delivery.Video.from_media_id'
-                        ) as from_media_id:
-            from_media_id.return_value = api.Video({
-                'key': 'video-key',
-                'custom': {
-                    'sms_acl': 'acl:USER_mb2174:',
-                    'sms_media_id': 'media:34:',
-                }
-            })
-            self.assertEqual(api.Video.from_media_id(34).acl, ['USER_mb2174'])
-
-            r = self.client.get(reverse(
-                'legacysms:download_media',
-                kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-            self.assertEqual(r.status_code, 403)
-
-            self.client.force_login(User.objects.create(username='spqr1'))
-            r = self.client.get(reverse(
-                'legacysms:download_media',
-                kwargs={'media_id': 34, 'clip_id': 56, 'extension': 'mp4'}))
-            self.assertEqual(r.status_code, 403)
 
 
 class MediaPageTest(TestCaseWithFixtures):

--- a/legacysms/views.py
+++ b/legacysms/views.py
@@ -3,12 +3,11 @@ Django views.
 
 """
 import logging
-from django.http import Http404, HttpResponse
+from django.http import Http404
 from django.shortcuts import redirect, render
 from django.urls import reverse
 import requests
 
-from mediaplatform_jwp.api import delivery as api
 from mediaplatform import models as mpmodels
 
 from . import redirect as legacyredirect
@@ -64,109 +63,14 @@ CONTENT_TYPE_FOR_DOWNLOAD_EXTENSION = {
 
 
 def download_media(request, media_id, clip_id, extension):
-    # NB: clip_id is ignored but we require it for two reasons: 1) compatibility with the legacy
-    # SMS URL scheme and 2) so that we know which URL to redirect to if the corresponding media
-    # item cannot be found in the JWPlatform DB.
+    item = _find_media_item(media_id, request)
 
-    # Locate the matching JWPlatform video resource.
-    try:
-        video = api.Video.from_media_id(media_id, preferred_media_type='video')
-    except api.VideoNotFoundError:
-        # If we cannot find the item, simply redirect to the legacy SMS.
-        LOG.info('download: failed to find matching video for media id %s', media_id)
-        return legacyredirect.media_download(media_id, clip_id, extension)
+    # If we can't find the item, return a 404 response
+    if item is None:
+        raise Http404()
 
-    video.check_user_access(request.user)
-
-    # Fetch the media download information from JWPlatform.
-    try:
-        r = DEFAULT_REQUESTS_SESSION.get(api.pd_api_url(f'/v2/media/{video.key}', format='json'),
-                                         timeout=5)
-    except requests.Timeout:
-        LOG.warn('Timed out when retrieving information on video "%s" from JWPlatform', video)
-        return HttpResponse(status=502)  # Bad gateway
-
-    # Check that the call to JWPlatform succeeded.
-    try:
-        r.raise_for_status()
-    except requests.HTTPError as e:
-        LOG.warn('Got HTTP error when retrieving information on video "%s" from JWPlatform', video)
-        LOG.warn('Error was: %s', e)
-        return HttpResponse(status=502)  # Bad gateway
-
-    # Parse response as JSON
-    try:
-        media_info = r.json()
-    except Exception as e:
-        LOG.warn(('Failed to parse JSON response when retrieving information on video "%s" from '
-                  'JWPlatform'), video)
-        LOG.warn('Error was: %s', e)
-        return HttpResponse(status=502)  # Bad gateway
-
-    # The response should be of the following form according to
-    # https://developer.jwplayer.com/jw-platform/docs/delivery-api-reference/#!/media/get_v2_media_media_id
-    #
-    #   {
-    #       "playlist": [
-    #           {
-    #               "sources": [
-    #                   {
-    #                       "width": <number>, "height": <number>, "file": <url>,
-    #                       "type": <mime-type>
-    #                   }
-    #               ]
-    #           }
-    #       ]
-    #   }
-    #
-    # In accordance with RFC 1122 § 1.2.2, we are "liberal in what we accept" when trying to get
-    # the list of sources:
-    try:
-        playlist_item = media_info.get('playlist', [])[0]
-    except IndexError:
-        playlist_item = {}
-    sources = playlist_item.get('sources', [])
-
-    # We now need to find *which* video/audio source to redirect the user back to. Firstly,
-    # determine which content/type we're looking for based on the extension. If we know of no such
-    # content type, return a 404 response. We don't redirect back to the legacy SMS here because we
-    # want to know earlier rather than later if the list of extensions in
-    # CONTENT_TYPE_FOR_DOWNLOAD_EXTENSION is incomplete and a 404 is a louder signal than a
-    # redirect :).
-    try:
-        desired_content_type = CONTENT_TYPE_FOR_DOWNLOAD_EXTENSION[extension.lower()]
-    except KeyError:
-        LOG.info('Could not match extension "%s" to a known content type', extension)
-        raise Http404('Unknown extension: %s'.format(extension))
-
-    # Filter the sources by this content type and then find the one with the largest height.
-    # We assume that the tallest source is approximately the highest quality version available.
-    sources_with_correct_type = [
-        source for source in sources if source.get('type', '') == desired_content_type
-    ]
-
-    # If the filtered sources list is empty, redirect back to the legacy SMS to try and deal with
-    # it.
-    if len(sources_with_correct_type) == 0:
-        LOG.info('download: failed to find source of content type %s for media id %s',
-                 desired_content_type, media_id)
-        return legacyredirect.media_download(media_id, clip_id, extension)
-
-    # Find best source. I.e. the one with greatest height
-    best_source = sources_with_correct_type[0]
-    for candidate_source in sources_with_correct_type[1:]:
-        if candidate_source.get('height', 0) > best_source.get('height', 0):
-            best_source = candidate_source
-
-    # Get the source URL
-    try:
-        url = best_source['file']
-    except KeyError:
-        LOG.warn('download: source is missing file key: %s', best_source)
-        return legacyredirect.media_download(media_id, clip_id, extension)
-
-    # Redirect to the direct download URL for the media item.
-    return redirect(url)
+    # Redirect to the source page
+    return redirect(reverse('api:media_source', kwargs={'pk': item.id}))
 
 
 def media(request, media_id):


### PR DESCRIPTION
Use the same strategy we use for media pages and for embed links for download links. This somehow got overlooked in the move away from putting JWP APIs on our critical path.

Pleasingly, this deletes a *lot* of crusty old code.