### PR TITLE
frontend: NavigationPanel: use fallback for profile displayName

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -427,6 +427,7 @@ class ProfileSerializer(serializers.Serializer):
     channels = ChannelDetailSerializer(
         help_text="List of channels which the user has edit rights on", many=True)
     displayName = serializers.CharField(source='person.displayName', required=False)
+    visibleName = serializers.CharField(source='person.visibleName', required=False)
     avatarImageUrl = serializers.SerializerMethodField()
 
     def get_avatarImageUrl(self, obj):

--- a/ui/frontend/src/api.ts
+++ b/ui/frontend/src/api.ts
@@ -127,6 +127,7 @@ export interface IProfileResponse {
   username?: string;
   channels: IChannelResource[];
   displayName?: string;
+  visibleName?: string;
   avatarImageUrl?: string;
 };
 

--- a/ui/frontend/src/components/NavigationPanel.js
+++ b/ui/frontend/src/components/NavigationPanel.js
@@ -20,6 +20,15 @@ import SignOutIcon from '@material-ui/icons/ExitToApp';
 
 import ChannelsMuiList from './ChannelsMuiList';
 
+/**
+ * Return a name for the user for use in display. Keeps going through profile fields until it
+ * finds a non-falsy one. As a last resort, or if the profile is itself falsy, the user is named
+ * "Anonymous".
+ */
+const profileDisplayName = profile => (
+  (profile && (profile.displayName || profile.visibleName || profile.username)) || 'Anonymous'
+);
+
 /** Side panel for the current user providing navigation links. */
 const NavigationPanel = ({ profile, classes }) => <div className={ classes.root }>
   {
@@ -28,13 +37,13 @@ const NavigationPanel = ({ profile, classes }) => <div className={ classes.root 
     <div>
       <div className={ classes.profileBar }>
         <Avatar
-          alt={ profile.displayName }
+          alt={ profileDisplayName(profile) }
           classes={{ root: classes.avatar }}
           src={ profile.avatarImageUrl }
         >
-          { profile.avatarImageUrl ? null : profile.displayName[0] }
+          { profile.avatarImageUrl ? null : profileDisplayName(profile)[0] }
         </Avatar>
-        <Typography variant='title'>{ profile.displayName }</Typography>
+        <Typography variant='title'>{ profileDisplayName(profile) }</Typography>
         <div className={ classes.profileUsernameContainer }>
           <Typography variant='caption' className={ classes.profileUsername }>
             { profile.username }
@@ -120,6 +129,7 @@ NavigationPanel.propTypes = {
     displayName: PropTypes.string,
     isAnonymous: PropTypes.bool.isRequired,
     username: PropTypes.string,
+    visibleName: PropTypes.string,
   }),
 };
 


### PR DESCRIPTION
Some users do not have displayName set in their lookup profile. Expose the visibleName property as a backup.

Users whose displayName was empty caused a client-side failure resulting in a blank screen in production. Add a set of fallback options for getting some sort of display name.

This was deployed to development and confirmed by @si202cam that it let him log in to the site.