### PR TITLE
mediaplatform: admin: make it a bit more convenient to add channels

### DIFF
--- a/mediaplatform/admin.py
+++ b/mediaplatform/admin.py
@@ -194,7 +194,7 @@ class ChannelAdminForm(forms.ModelForm):
 @admin.register(models.Channel)
 class ChannelAdmin(VersionAdmin):
     fields = (
-        'title', 'description', 'item_count', 'created_at', 'updated_at',
+        'title', 'description', 'billing_account', 'item_count', 'created_at', 'updated_at',
         'deleted_at'
     )
     search_fields = ('id', 'title', 'description')

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -881,6 +881,13 @@ class BillingAccount(models.Model):
             models.Index(fields=['lookup_instid']),
         )
 
+    def __str__(self):
+        if self.description != '':
+            paren = self.lookup_instid
+        else:
+            paren = f'{self.lookup_instid}: {self.description}'
+        return f'{self.id} ({paren})'
+
 
 @receiver(post_save, sender=MediaItem)
 def _media_item_post_save_handler(*args, sender, instance, created, raw, **kwargs):


### PR DESCRIPTION
This is a very small PR.

As it stands, channels cannot be added in the admin because the billing_account field was omitted from the list of fields. Add the field back in and give billing account a more friendly ``__str__`` method so that it can be found in the admin.