### PR TITLE
Do not show media invisible to user in playlist view

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -411,7 +411,7 @@ class PlaylistDetailSerializer(PlaylistSerializer):
 
     channel = ChannelSerializer(read_only=True)
 
-    media = MediaItemSerializer(many=True, source='ordered_media_item_queryset')
+    media = MediaItemSerializer(many=True)
 
     class Meta(PlaylistSerializer.Meta):
         fields = PlaylistSerializer.Meta.fields + ('channel', 'media')

--- a/api/tests/fixtures/mediaitems.yaml
+++ b/api/tests/fixtures/mediaitems.yaml
@@ -248,7 +248,7 @@
   pk: public
   fields:
     channel: channel1
-    media_items: ['public', 'signedin', 'deleted', 'notfound']
+    media_items: ['a', 'populated', 'deleted', 'useronly', 'notfound']
     created_at: 2010-09-15 14:40:45
     updated_at: 2010-09-15 14:40:45
 

--- a/api/views.py
+++ b/api/views.py
@@ -637,6 +637,14 @@ class PlaylistView(PlaylistMixin, generics.RetrieveUpdateDestroyAPIView):
     """
     serializer_class = serializers.PlaylistDetailSerializer
 
+    def get_object(self):
+        obj = super().get_object()
+
+        # Add a list of all the media which is viewable by the current user. This is used by the
+        # detail serialiser.
+        obj.media = obj.ordered_media_item_queryset.viewable_by_user(self.request.user)
+        return obj
+
 
 class BillingAccountListMixin(ViewMixinBase):
     """


### PR DESCRIPTION
As noted in #398, we were inadvertently showing all media in playlists irrespective of whether the user should be able to see them. This PR consists of two commits; one closes the issue and the other adds a test for media items being returned in playlists which was missing.

Closes #398.