### PR TITLE
Explicitly included the 'fetch' polyfill.

### DIFF
--- a/ui/frontend/public/index.html
+++ b/ui/frontend/public/index.html
@@ -44,7 +44,7 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
     <!-- Polyfill for IE11, etc. -->
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,fetch"></script>
 
     <!-- Warn users about old browsers -->
     <script>


### PR DESCRIPTION
Explicitly included the 'fetch' polyfill to potentially avoid the IE11 'fetch not found' bug experienced with the Research Dashboard.