### PR TITLE
frontend: PlaylistOverlay: fix indexing bug

### DIFF
--- a/ui/frontend/src/components/PlaylistOverlay.tsx
+++ b/ui/frontend/src/components/PlaylistOverlay.tsx
@@ -163,7 +163,12 @@ export const PlaylistOverlay = withStyles(styles)(
           <JWPlayerPlaylistProvider>{
             ({ playlist, index, setIndex }) => (
               <EmbedPlaylist classes={{ root: classes.playlist }}>{
-                playlist.filter(filterPlaylistItem).map((item, itemIndex) => (
+                playlist.map((item, itemIndex) => (
+                  // We can't use playlist.filter() before .map() because the index of the item
+                  // must match the index in the JWP playlist for the selected highlight to be
+                  // correct and for clicking on the playlist item to work.
+                  filterPlaylistItem(item)
+                  ?
                   <EmbedPlaylistItem
                     onClick={() => setIndex(itemIndex)}
                     selected={ itemIndex === index }
@@ -172,6 +177,8 @@ export const PlaylistOverlay = withStyles(styles)(
                     <EmbedPlaylistImage selected={ itemIndex === index } url={ item.image }/>
                     <EmbedPlaylistCaption title={ item.title } />
                   </EmbedPlaylistItem>
+                  :
+                  null
                 ))
               }</EmbedPlaylist>
             )


### PR DESCRIPTION
As noted in #408, the logic used to highlight the current media item and to select a new one in the embedded playlist view was faulty when the playlist was being searched.

The root cause was the fact that the index of the item being rendered in the playlist overlay must match the index of the item in the JWP playlist itself. Filtering the list of items beforehand by the search breaks this invariant. We fix this by imply rendering a null element for playlist items which should not be rendered.

Closes #408