### PR TITLE
mediaplatform_jwp: proxy player library

### DIFF
--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -409,7 +409,7 @@ class PlayerLibraryViewTestCase(ViewTestCase):
 
     def test_caching(self):
         """
-        Multiple calls to the same view cache the result and only call requests.ge tonce.
+        Multiple calls to the same view cache the result and only call requests.get once.
 
         """
         mock_js = 'THIS IS A MOCK LIBRARY'

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -398,8 +398,23 @@ class PlayerLibraryViewTestCase(ViewTestCase):
         The player library endpoint redirects to a URL.
 
         """
-        with mock.patch('time.time') as mock_time:
+        mock_js = 'THIS IS A MOCK LIBRARY'
+        with mock.patch('time.time') as mock_time, mock.patch('requests.get') as mock_get:
+            mock_get.return_value.text = mock_js
             mock_time.return_value = 1234
             expected_url = api.player_library_url()
             r = self.client.get(reverse('ui:player_lib'))
-        self.assertRedirects(r, expected_url, fetch_redirect_response=False)
+        mock_get.assert_called_with(expected_url)
+        self.assertEqual(r.content.decode('utf8'), mock_js)
+
+    def test_caching(self):
+        """
+        Multiple calls to the same view cache the result and only call requests.ge tonce.
+
+        """
+        mock_js = 'THIS IS A MOCK LIBRARY'
+        with mock.patch('requests.get') as mock_get:
+            mock_get.return_value.text = mock_js
+            for _ in range(10):
+                self.client.get(reverse('ui:player_lib'))
+        mock_get.assert_called_once()

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -85,5 +85,5 @@ urlpatterns = [
     path('search', TemplateView.as_view(template_name="index.html"), name='search'),
 
     # A pre-configured JWPlayer library.
-    path('lib/player.js', views.PlayerLibraryView.as_view(), name='player_lib'),
+    path('lib/player.js', views.jwplayer_library_js, name='player_lib'),
 ]


### PR DESCRIPTION
As noted in #407, we were signing player.js URLs incorrectly. Implement the legacy signing method for player URLs as documented at [1]. Looking at the signing method, there are a number of weaknesses:

1. MD5 is a broken hash.

2. The secret is appended to the value to be hashed meaning that the hash state preceding the secret is known. HMAC, for example, guards against this explicitly.

To avoid exposing the signatures to all and sundry, we proxy the player library so that the signature only goes between our server and JWP. We cache the resulting response to avoid making a round-trip delay to JWP be the common case and instead to make the common case that the player JavaScript is served from the cache.

[1] https://developer.jwplayer.com/jw-platform/docs/developer-guide/delivery-api/legacy-url-token-signing/

Closes #407